### PR TITLE
feat: NFT support for Pool contract

### DIFF
--- a/.dapprpc
+++ b/.dapprpc
@@ -1,6 +1,0 @@
-export DAPP_TEST_TIMESTAMP=0
-export DAPP_SOLC_VERSION=0.7.6
-export DAPP_BUILD_OPTIMIZE=1
-export DAPP_SRC="contracts"
-DAPP_REMAPPINGS="\
-ds-test/=lib/ds-test/src/

--- a/.dapprpc
+++ b/.dapprpc
@@ -1,0 +1,6 @@
+export DAPP_TEST_TIMESTAMP=0
+export DAPP_SOLC_VERSION=0.7.6
+export DAPP_BUILD_OPTIMIZE=1
+export DAPP_SRC="contracts"
+DAPP_REMAPPINGS="\
+ds-test/=lib/ds-test/src/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "lib/openzeppelin-contracts"]
-	path = lib/openzeppelin-contracts
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/src/NFTPool.sol
+++ b/src/NFTPool.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.6;
+pragma experimental ABIEncoderV2;
+
+import {DaiPool, Erc20Pool, ReceiverWeight, Dai} from "./Pool.sol";
+import {IERC721} from "openzeppelin-contracts/token/ERC721/IERC721.sol";
+
+/// @notice NFT pool contract to support streaming based on NFT ownership
+/// A NFT can be a sender or a receiver, a unique id is generated based on
+/// NFT registry address and the tokenId
+contract NFTPool is Erc20Pool {
+    modifier nftOwner (address nftRegistry, uint tokenId) {
+        require(IERC721(nftRegistry).ownerOf(tokenId) == msg.sender, "not-NFT-owner"); _;
+    }
+    constructor(uint64 cycleSecs, Dai dai) Erc20Pool(cycleSecs, dai) {}
+
+    /// @notice generates a unique 20 bytes by hashing the nft registry  and tokenId
+    /// @param nftRegistry address of the NFT specific registry
+    /// @param tokenId the unique token id for the NFT registry
+    function nftID(address nftRegistry, uint128 tokenId) public pure returns (address id) {
+        // gas optimized without local variables
+        return address(uint160(uint256(
+                keccak256(abi.encodePacked(nftRegistry, tokenId)
+                ))));
+    }
+
+    /// @notice collect the funds of an NFT. Requires the msg.sender to own the NFT
+    /// @param nftRegistry address of the NFT specific registry
+    /// @param tokenId the unique token id for the NFT registry
+    function collect(address nftRegistry, uint128 tokenId) public nftOwner(nftRegistry, tokenId) {
+        uint128 collected = _collectInternal(nftID(nftRegistry, tokenId));
+        if (collected > 0) {
+            // msg.sender === nft owner
+            _transferToSender(msg.sender, collected);
+        }
+        emit Collected(msg.sender, collected);
+    }
+
+    /// @notice updateSender based on the ownership of an NFT
+    /// @param nftRegistry address of the NFT specific registry
+    /// @param tokenId the unique token id for the NFT registry
+    function updateSender(
+        address nftRegistry,
+        uint128 tokenId,
+        uint128 topUpAmt,
+        uint128 withdraw,
+        uint128 amtPerSec,
+        ReceiverWeight[] calldata updatedReceivers,
+        ReceiverWeight[] calldata updatedProxies
+    ) public nftOwner(nftRegistry, tokenId) {
+        // msg.sender === nft owner
+        _transferToContract(msg.sender, topUpAmt);
+        uint128 withdrawn =
+        _updateSenderInternal(nftID(nftRegistry, tokenId), topUpAmt, withdraw, amtPerSec,
+            updatedReceivers, updatedProxies);
+        _transferToSender(msg.sender, withdrawn);
+    }
+}

--- a/src/test/BaseTest.t.sol
+++ b/src/test/BaseTest.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.6;
+pragma experimental ABIEncoderV2;
+
+import "ds-test/test.sol";
+import "./User.t.sol";
+
+interface Hevm {
+    function warp(uint256) external;
+}
+contract BaseTest is DSTest {
+
+    uint constant SECONDS_PER_YEAR = 31536000;
+    uint64 constant CYCLE_SECS = 30 days;
+    uint constant TOLERANCE = 10 ** 10;
+
+    function fundingInSeconds(uint fundingPerCycle) public pure returns(uint) {
+        return fundingPerCycle/CYCLE_SECS;
+    }
+
+    // assert equal two variables with a wei tolerance
+    function assertEqTol(uint actual, uint expected, bytes32 msg_) public {
+        uint diff;
+        if (actual > expected) {
+            diff = actual -expected;
+        } else {
+            diff = expected - actual;
+        }
+        if (diff > TOLERANCE) {
+            emit log_named_bytes32(string(abi.encodePacked(msg_)), "Assert Equal Failed");
+            emit log_named_uint("Expected", expected);
+            emit log_named_uint("Actual  ", actual);
+            emit log_named_uint("Diff    ", diff);
+
+        }
+        assertTrue(diff <= TOLERANCE);
+    }
+}

--- a/src/test/NFTPool.t.sol
+++ b/src/test/NFTPool.t.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.6;
+pragma experimental ABIEncoderV2;
+
+import "ds-test/test.sol";
+import "./BaseTest.t.sol";
+
+import {ERC721} from "openzeppelin-contracts/token/ERC721/ERC721.sol";
+import "openzeppelin-contracts/token/ERC721/ERC721.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
+import "openzeppelin-contracts/utils/Counters.sol";
+
+contract TestNFT is ERC721, Ownable {
+    using Counters for Counters.Counter;
+    Counters.Counter private _tokenIds;
+
+    constructor() ERC721("Test NFT", "TNFT") {}
+
+    function mint(address receiver) external onlyOwner returns (uint256) {
+        _tokenIds.increment();
+
+        uint256 newNftTokenId = _tokenIds.current();
+        _mint(receiver, newNftTokenId);
+
+        return newNftTokenId;
+    }
+}
+
+contract NFTPoolTest is BaseTest {
+    Hevm public hevm;
+    NFTPool pool;
+    Dai dai;
+
+    // test user
+    User public alice;
+    address public alice_;
+
+    User public bob;
+    address public bob_;
+
+    TestNFT public nftRegistry;
+    address public nftRegistry_;
+
+    function setUp() public {
+        hevm = Hevm(HEVM_ADDRESS);
+
+        dai = new Dai();
+        pool = new NFTPool(CYCLE_SECS, dai);
+
+        alice = new User(pool, dai);
+        alice_ = address(alice);
+
+        bob = new User(pool, dai);
+        bob_ = address(bob);
+
+        nftRegistry = new TestNFT();
+        nftRegistry_ = address(nftRegistry);
+    }
+
+    function setupNFTStreaming(User from, address to, uint lockAmount, uint daiPerSecond) public returns (uint tokenId) {
+        dai.transfer(address(from), lockAmount);
+
+        tokenId = nftRegistry.mint(address(from));
+        assertEq(nftRegistry.ownerOf(tokenId), address(from));
+
+        from.streamWithNFT(nftRegistry_, tokenId, to, daiPerSecond, lockAmount);
+        return tokenId;
+    }
+
+    function testBasicStreamWithNFT() public {
+        uint lockAmount = 5_000 ether;
+        // 1000 DAI per month
+        uint daiPerSecond = 0.000001 ether;
+        address to = alice_;
+        User from = bob;
+
+        // bob streams to alice
+        uint tokenId = setupNFTStreaming(from, to, lockAmount, daiPerSecond);
+
+        // two cycles
+        uint t = 60 days;
+        hevm.warp(block.timestamp + t);
+
+        alice.collect();
+        assertEqTol(dai.balanceOf(alice_), t * daiPerSecond, "incorrect received amount");
+
+        // withdraw
+        uint withdrawAmount = 30 ether;
+        assertEq(dai.balanceOf(bob_), 0, "non-zero-balance");
+        bob.withdraw(nftRegistry_, tokenId, withdrawAmount);
+        assertEq(dai.balanceOf(bob_), withdrawAmount, "withdraw-fail");
+    }
+
+    function testFailWithdraw() public {
+        uint lockAmount = 5_000 ether;
+        // 1000 DAI per month
+        uint daiPerSecond = 0.000001 ether;
+        address to = alice_;
+        User from = bob;
+
+        // bob streams to alice
+        uint tokenId = setupNFTStreaming(from, to, lockAmount, daiPerSecond);
+
+        // transfer nft to random address
+        bob.transferNFT(nftRegistry_, address(0x123), tokenId);
+        uint withdrawAmount = 30 ether;
+        bob.withdraw(nftRegistry_, tokenId, withdrawAmount);
+    }
+
+    function testTransferNFT() public {
+        uint lockAmount = 5_000 ether;
+        // 1000 DAI per month
+        uint daiPerSecond = 0.000001 ether;
+        address to = alice_;
+        User from = bob;
+
+        // bob streams to alice
+        uint tokenId = setupNFTStreaming(from, to, lockAmount, daiPerSecond);
+
+        User charly = new User(pool, dai);
+        address charly_ = address(charly);
+
+        // transfer nft to charly address
+        bob.transferNFT(nftRegistry_, address(charly), tokenId);
+
+        // charly withdraw
+        uint withdrawAmount = 30 ether;
+        assertEq(dai.balanceOf(charly_), 0, "non-zero-balance");
+        charly.withdraw(nftRegistry_, tokenId, withdrawAmount);
+        assertEq(dai.balanceOf(charly_), withdrawAmount, "withdraw-fail");
+    }
+
+    function testBasicNFTtoNFT() public {
+        uint lockAmount = 5_000 ether;
+        // 1000 DAI per month
+        uint daiPerSecond = 0.000001 ether;
+
+        uint aliceNFT = nftRegistry.mint(address(alice));
+        uint bobNFT = nftRegistry.mint(address(bob));
+
+        dai.transfer(bob_, lockAmount);
+
+        // unique id for alice NFT
+        address to = pool.nftID(nftRegistry_, uint128(aliceNFT));
+
+        // bob streams to alice
+        bob.streamWithNFT(nftRegistry_, bobNFT, to, daiPerSecond, lockAmount);
+
+        // two cycles
+        uint t = 60 days;
+        hevm.warp(block.timestamp + t);
+
+        // alice collects with her NFT
+        alice.collect(nftRegistry_, aliceNFT);
+
+        assertEqTol(dai.balanceOf(alice_), t * daiPerSecond, "incorrect received amount");
+    }
+
+    function testBasicAddressToNFT() public {
+        uint lockAmount = 5_000 ether;
+        // 1000 DAI per month
+        uint daiPerCycle = 10 ether;
+        uint daiPerSecond = fundingInSeconds(daiPerCycle);
+
+        dai.transfer(bob_, lockAmount);
+
+        uint aliceNFT = nftRegistry.mint(address(alice));
+        // unique id for alice NFT
+        address id = pool.nftID(nftRegistry_, uint128(aliceNFT));
+
+
+        // bob streams with address to alice NFT
+        bob.streamWithAddress(id, daiPerSecond, lockAmount);
+
+        // two cycles
+        uint t = 60 days;
+        hevm.warp(block.timestamp + t);
+
+        // alice collects with her NFT
+        alice.collect(nftRegistry_, aliceNFT);
+
+        assertEqTol(dai.balanceOf(alice_), t * daiPerSecond, "incorrect received amount");
+    }
+}

--- a/src/test/User.t.sol
+++ b/src/test/User.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.6;
+pragma experimental ABIEncoderV2;
+
+import "./../NFTPool.sol";
+import {IERC721} from "openzeppelin-contracts/token/ERC721/IERC721.sol";
+
+contract User {
+    NFTPool public pool;
+    Dai public dai;
+    constructor(NFTPool pool_, Dai dai_) {
+        pool = pool_;
+        dai = dai_;
+    }
+
+    function withdraw(uint withdrawAmount) public {
+        pool.updateSender(0, uint128(withdrawAmount), 0,  new ReceiverWeight[](0), new ReceiverWeight[](0));
+    }
+
+    function withdraw(address nftRegistry, uint tokenId, uint withdrawAmount) public {
+        pool.updateSender(nftRegistry, uint128(tokenId), 0, uint128(withdrawAmount), 0,  new ReceiverWeight[](0), new ReceiverWeight[](0));
+    }
+
+    function collect() public {
+        pool.collect();
+    }
+
+    function collect(address nftRegistry, uint tokenId) public {
+        pool.collect(nftRegistry, uint128(tokenId));
+    }
+
+    function streamWithAddress(address to, uint daiPerSecond, uint lockAmount) public {
+        ReceiverWeight[] memory receivers = new ReceiverWeight[](1);
+        receivers[0] = ReceiverWeight({receiver:to, weight:pool.SENDER_WEIGHTS_SUM_MAX()});
+
+        dai.approve(address(pool), type(uint).max);
+        pool.updateSender(uint128(lockAmount), 0, uint128(daiPerSecond), receivers, new ReceiverWeight[](0));
+    }
+
+    function streamWithNFT(address nftRegistry, uint tokenId, address to, uint daiPerSecond, uint lockAmount) public {
+        ReceiverWeight[] memory receivers = new ReceiverWeight[](1);
+        receivers[0] = ReceiverWeight({receiver:to, weight:pool.SENDER_WEIGHTS_SUM_MAX()});
+
+        dai.approve(address(pool), type(uint).max);
+        pool.updateSender(nftRegistry, uint128(tokenId), uint128(lockAmount), 0, uint128(daiPerSecond), receivers, new ReceiverWeight[](0));
+    }
+
+    function transferNFT(address nftRegistry,address to, uint tokenId) public {
+        IERC721(nftRegistry).transferFrom(address(this), to, tokenId);
+    }
+}


### PR DESCRIPTION
Here is my PR to support NFT streaming in the funding pool.

**Pool Contract**
- all internal methods have a underscore
- introduction of `address id` replace all internal usages of msg.sender with `id`
- kept all public view method interfaces which use msg.sender
   - we can break the interface and require `address id` param or a separate method
- no proxy support for NFT because we want to remove it

**NFT Pool Contract**
- unique id based on the `keccak256(abi.encodePacked(nftRegistry, tokenId)` 
- collect and updateSender requires the NFT ownership
   - we might should consider renaming the function to `updateNFTSender`
   
**Tests**
- added first basic tests for NFT streaming
   - NFT to address streaming
   - NFT to NFT streaming
   - address to NFT streaming
- the old javascript tests are still required to be migrated