### PR TITLE
feat: virtual updateSender and collect

### DIFF
--- a/src/NFTPool.sol
+++ b/src/NFTPool.sol
@@ -62,7 +62,7 @@ contract NFTPool is DaiPool {
         uint128 withdraw,
         uint128 amtPerSec,
         ReceiverWeight[] calldata updatedReceivers
-    ) public nftOwner(nftRegistry, tokenId) {
+    ) public virtual nftOwner(nftRegistry, tokenId) {
         _sendFromNFT(nftID(nftRegistry, tokenId), topUpAmt, withdraw, amtPerSec, updatedReceivers);
     }
 

--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -179,7 +179,7 @@ abstract contract Pool {
 
     /// @notice Collects all received funds available for collection
     /// by the sender of the message and sends them to that sender
-    function collect() public {
+    function collect() public virtual {
         uint128 collected = _collectInternal(msg.sender);
         if (collected > 0) {
             _transferToSender(msg.sender, collected);
@@ -504,7 +504,7 @@ contract EthPool is Pool {
         uint128 withdraw,
         uint128 amtPerSec,
         ReceiverWeight[] calldata updatedReceivers
-    ) public payable {
+    ) public virtual payable {
         uint128 withdrawn =
             _updateSenderInternal(
                 msg.sender,
@@ -565,7 +565,7 @@ contract Erc20Pool is Pool {
         uint128 withdraw,
         uint128 amtPerSec,
         ReceiverWeight[] calldata updatedReceivers
-    ) public {
+    ) public virtual {
         _transferToContract(msg.sender, topUpAmt);
         uint128 withdrawn =
             _updateSenderInternal(msg.sender, topUpAmt, withdraw, amtPerSec, updatedReceivers);
@@ -605,7 +605,7 @@ contract DaiPool is Erc20Pool {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public {
+    ) public virtual {
         IDai(address(erc20)).permit(msg.sender, address(this), nonce, expiry, true, v, r, s);
         updateSender(topUpAmt, withdraw, amtPerSec, updatedReceivers);
     }


### PR DESCRIPTION
Making the main pool methods (`updateSender, collect`) virtual allows to inherit from the Pool contract.

This enables to add custom streaming logic on top.
