### PR TITLE
feat: simplified nextWeightPrunning

### DIFF
--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -409,12 +409,9 @@ abstract contract Pool {
         Sender storage sender = senders[id];
         // Iterating over receivers, see `ReceiverWeights` for details
         address receiverAddr = ReceiverWeightsImpl.ADDR_ROOT;
-        address hint = ReceiverWeightsImpl.ADDR_ROOT;
         while (true) {
             uint32 weight;
-            (receiverAddr, weight) = sender.receiverWeights.nextWeightPruning(
-                receiverAddr
-            );
+            (receiverAddr, weight) = sender.receiverWeights.nextWeightPruning(receiverAddr);
             if (receiverAddr == ReceiverWeightsImpl.ADDR_ROOT) break;
             int128 amtPerSecDelta = int128(uint128(weight)) * amtPerWeightPerSecDelta;
             _setReceiverDeltaFromNow(receiverAddr, amtPerSecDelta, timeEnd);

--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -412,9 +412,8 @@ abstract contract Pool {
         address hint = ReceiverWeightsImpl.ADDR_ROOT;
         while (true) {
             uint32 weight;
-            (receiverAddr, hint, weight) = sender.receiverWeights.nextWeightPruning(
-                receiverAddr,
-                hint
+            (receiverAddr, weight) = sender.receiverWeights.nextWeightPruning(
+                receiverAddr
             );
             if (receiverAddr == ReceiverWeightsImpl.ADDR_ROOT) break;
             int128 amtPerSecDelta = int128(uint128(weight)) * amtPerWeightPerSecDelta;

--- a/src/libraries/ReceiverWeights.sol
+++ b/src/libraries/ReceiverWeights.sol
@@ -42,9 +42,9 @@ library ReceiverWeightsImpl {
         while (receiver != ADDR_ROOT) {
             weight = self.data[receiver].weight;
             if (weight != 0) break;
-            address nextReceiver = self.data[receiver].next;
-            delete self.data[receiver];
-            receiver = nextReceiver;
+            address deleteReceiver = receiver;
+            receiver = self.data[receiver].next;
+            delete self.data[deleteReceiver];
         }
         // prevReceiver.next needs to be updated if previously stored successor
         // got removed

--- a/src/libraries/ReceiverWeights.sol
+++ b/src/libraries/ReceiverWeights.sol
@@ -41,8 +41,8 @@ library ReceiverWeightsImpl {
         receiver = nextReceiverHint;
         while (receiver != ADDR_ROOT) {
             weight = self.data[receiver].weight;
-            address nextReceiver = self.data[receiver].next;
             if (weight != 0) break;
+            address nextReceiver = self.data[receiver].next;
             delete self.data[receiver];
             receiver = nextReceiver;
         }

--- a/src/libraries/ReceiverWeights.sol
+++ b/src/libraries/ReceiverWeights.sol
@@ -31,17 +31,10 @@ library ReceiverWeightsImpl {
     /// or ADDR_ROOT to start iterating
     /// @return receiver The receiver address, ADDR_ROOT if the end of the list was reached
     /// @return weight The receiver weight
-    function nextWeightPruning(
-        ReceiverWeights storage self,
-        address prevReceiver
-    )
+    function nextWeightPruning(ReceiverWeights storage self, address prevReceiver)
         internal
-        returns (
-            address receiver,
-            uint32 weight
-        )
+        returns (address receiver, uint32 weight)
     {
-        address nextReceiver = self.data[prevReceiver].next;
         // next receiver hint because if it is an zero weight receiver
         // it will be removed and not the next one
         address nextReceiverHint = self.data[prevReceiver].next;


### PR DESCRIPTION
I think it is not required to pass the `prevReceiverHint` as a parameter and `receiverHint` as a return parameter in the **nextWeightPrunning** function.

- param prevReceiverHint
   - It can be read inside the function `address nextReceiverHint = self.data[prevReceiver].next;`
   - i think it is cleaner if only the prevReceiver needs to be passed
   
- returned receiverHint
  - not required anymore

The tests are passing or did I miss anything?