### PR TITLE
Add give

### DIFF
--- a/src/DaiPool.sol
+++ b/src/DaiPool.sol
@@ -42,8 +42,8 @@ contract DaiPool is ERC20Pool {
     /// This function is an extension of `updateSender`, see its documentation for more details.
     ///
     /// The sender must sign a Dai permission document allowing the pool to spend their funds.
-    /// The document's `nonce` and `expiry` must be passed here along the parts of its signature.
     /// These parameters will be passed to the Dai contract by this function.
+    /// @param permitArgs The Dai permission arguments.
     function updateSenderAndPermit(
         uint128 topUpAmt,
         uint128 withdraw,
@@ -66,7 +66,10 @@ contract DaiPool is ERC20Pool {
     /// @notice Updates all the parameters of a sub-sender of the sender of the message
     /// and permits spending sender's Dai by the pool.
     /// This function is an extension of `updateSubSender`, see its documentation for more details.
-    /// @param subSenderId The id of the sender's sub-sender
+    ///
+    /// The sender must sign a Dai permission document allowing the pool to spend their funds.
+    /// These parameters will be passed to the Dai contract by this function.
+    /// @param permitArgs The Dai permission arguments.
     function updateSubSenderAndPermit(
         uint256 subSenderId,
         uint128 topUpAmt,
@@ -79,6 +82,41 @@ contract DaiPool is ERC20Pool {
         return updateSubSender(subSenderId, topUpAmt, withdraw, currReceivers, newReceivers);
     }
 
+    /// @notice Gives funds from the sender of the message to the receiver
+    /// and permits spending sender's Dai by the pool.
+    /// This function is an extension of `give`, see its documentation for more details.
+    ///
+    /// The sender must sign a Dai permission document allowing the pool to spend their funds.
+    /// These parameters will be passed to the Dai contract by this function.
+    /// @param permitArgs The Dai permission arguments.
+    function giveAndPermit(
+        address receiver,
+        uint128 amt,
+        PermitArgs calldata permitArgs
+    ) public {
+        permit(permitArgs);
+        give(receiver, amt);
+    }
+
+    /// @notice Gives funds from the sub-sender of the sender of the message to the receiver
+    /// and permits spending sender's Dai by the pool.
+    /// This function is an extension of `giveFromSubSender` see its documentation for more details.
+    ///
+    /// The sender must sign a Dai permission document allowing the pool to spend their funds.
+    /// These parameters will be passed to the Dai contract by this function.
+    /// @param permitArgs The Dai permission arguments.
+    function giveFromSubSenderAndPermit(
+        uint256 subSenderId,
+        address receiver,
+        uint128 amt,
+        PermitArgs calldata permitArgs
+    ) public {
+        permit(permitArgs);
+        giveFromSubSender(subSenderId, receiver, amt);
+    }
+
+    /// @notice Permits the pool to spend the message sender's Dai.
+    /// @param permitArgs The Dai permission arguments.
     function permit(PermitArgs calldata permitArgs) internal {
         dai.permit(
             msg.sender,

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -85,6 +85,27 @@ contract ERC20Pool is Pool {
             );
     }
 
+    /// @notice Gives funds from the sender of the message to the receiver.
+    /// The receiver can collect them immediately.
+    /// @param receiver The receiver
+    /// @param amt The sent amount
+    function give(address receiver, uint128 amt) public {
+        _giveInternal(msg.sender, receiver, amt);
+    }
+
+    /// @notice Gives funds from the sub-sender of the sender of the message to the receiver.
+    /// The receiver can collect them immediately.
+    /// @param subSenderId The ID of the sub-sender
+    /// @param receiver The receiver
+    /// @param amt The given amount
+    function giveFromSubSender(
+        uint256 subSenderId,
+        address receiver,
+        uint128 amt
+    ) public {
+        _giveFromSubSenderInternal(msg.sender, subSenderId, receiver, amt);
+    }
+
     function _transfer(address userAddr, int128 amt) internal override {
         if (amt > 0) erc20.transfer(userAddr, uint128(amt));
         else if (amt < 0) erc20.transferFrom(userAddr, address(this), uint128(-amt));

--- a/src/EthPool.sol
+++ b/src/EthPool.sol
@@ -77,6 +77,21 @@ contract EthPool is Pool {
             );
     }
 
+    /// @notice Gives funds from the sender of the message to the receiver.
+    /// The receiver can collect them immediately.
+    /// @param receiver The receiver
+    function give(address receiver) public payable {
+        _giveInternal(msg.sender, receiver, uint128(msg.value));
+    }
+
+    /// @notice Gives funds from the sub-sender of the sender of the message to the receiver.
+    /// The receiver can collect them immediately.
+    /// @param subSenderId The id of the giver's sub-sender
+    /// @param receiver The receiver
+    function giveFromSubSender(uint256 subSenderId, address receiver) public payable {
+        _giveFromSubSenderInternal(msg.sender, subSenderId, receiver, uint128(msg.value));
+    }
+
     function _transfer(address userAddr, int128 amt) internal override {
         // Take into account the amount already transferred into the pool
         amt += int128(uint128(msg.value));

--- a/src/test/Pool.t.sol
+++ b/src/test/Pool.t.sol
@@ -537,4 +537,14 @@ abstract contract PoolTest is PoolUserUtils {
         flushCycles(receiver, 3, type(uint64).max, 0);
         collect(receiver, amt);
     }
+
+    function testFundsGivenFromSenderCanBeCollected() public {
+        sender.give(address(receiver), 10);
+        collect(receiver, 10);
+    }
+
+    function testFundsGivenFromSubSenderCanBeCollected() public {
+        sender.giveFromSubSender(SUB_SENDER_1, address(receiver), 10);
+        collect(receiver, 10);
+    }
 }

--- a/src/test/User.t.sol
+++ b/src/test/User.t.sol
@@ -37,6 +37,14 @@ abstract contract PoolUser {
         Receiver[] calldata newReceivers
     ) public virtual returns (uint128 withdrawn);
 
+    function give(address receiver, uint128 amt) public virtual;
+
+    function giveFromSubSender(
+        uint256 subSenderId,
+        address receiver,
+        uint128 amt
+    ) public virtual;
+
     function collect(address receiverAddr, Receiver[] calldata currReceivers)
         public
         returns (uint128 collected, uint128 dripped)
@@ -137,6 +145,20 @@ contract ERC20PoolUser is PoolUser {
         pool.erc20().approve(address(pool), toppedUp);
         return pool.updateSubSender(subSenderId, toppedUp, withdraw, currReceivers, newReceivers);
     }
+
+    function give(address receiver, uint128 amt) public override {
+        pool.erc20().approve(address(pool), amt);
+        pool.give(receiver, amt);
+    }
+
+    function giveFromSubSender(
+        uint256 subSenderId,
+        address receiver,
+        uint128 amt
+    ) public override {
+        pool.erc20().approve(address(pool), amt);
+        pool.giveFromSubSender(subSenderId, receiver, amt);
+    }
 }
 
 contract EthPoolUser is PoolUser {
@@ -195,5 +217,17 @@ contract EthPoolUser is PoolUser {
                 currReceivers,
                 newReceivers
             );
+    }
+
+    function give(address receiver, uint128 amt) public override {
+        pool.give{value: amt}(receiver);
+    }
+
+    function giveFromSubSender(
+        uint256 subSenderId,
+        address receiver,
+        uint128 amt
+    ) public override {
+        pool.giveFromSubSender{value: amt}(subSenderId, receiver);
     }
 }


### PR DESCRIPTION
Depends on https://github.com/radicle-dev/radicle-streaming/pull/51, closes https://github.com/radicle-dev/radicle-streaming/issues/30.

Adds `give` method, which gives funds to another user ready for immediate collection. Names "send" and "transfer" are already taken in Solidity :weary: 

~~There's no way for a sub-sender to `give`, is that going to be a problem? Sub-senders are needed only for maintaining stream configurations, so it doesn't make sense for a sub-sender to `give`. On the other hand maybe it's important for bookkeeping? Now that I'm thinking about it, do we need `give` on the funding pool level @manuelpolzhofer ? It's needed for the funding NFT contract, will it use that method for anything else than giving funds from itself to itself? OTOH it allows dripping to others :thinking:~~