### PR TITLE
Cheap collect

### DIFF
--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -240,9 +240,9 @@ abstract contract Pool {
         if (collectedCycle != 0 && collectedCycle <= currFinishedCycle) {
             int128 lastFundsPerCycle = int128(receiver.lastFundsPerCycle);
             for (; collectedCycle <= currFinishedCycle; collectedCycle++) {
-                lastFundsPerCycle += receiver.amtDeltas[collectedCycle - 1].nextCycle;
                 lastFundsPerCycle += receiver.amtDeltas[collectedCycle].thisCycle;
                 collected += uint128(lastFundsPerCycle);
+                lastFundsPerCycle += receiver.amtDeltas[collectedCycle].nextCycle;
             }
         }
 
@@ -354,10 +354,10 @@ abstract contract Pool {
         int128 fundsPerCycle = int128(receiver.lastFundsPerCycle);
         uint64 cycle = receiver.nextCollectedCycle;
         for (uint256 i = 0; i < count; i++) {
-            fundsPerCycle += receiver.amtDeltas[cycle - 1].nextCycle;
-            delete receiver.amtDeltas[cycle - 1];
             fundsPerCycle += receiver.amtDeltas[cycle].thisCycle;
             collectedAmt += uint128(fundsPerCycle);
+            fundsPerCycle += receiver.amtDeltas[cycle].nextCycle;
+            delete receiver.amtDeltas[cycle];
             cycle++;
         }
         receiver.lastFundsPerCycle = uint128(fundsPerCycle);


### PR DESCRIPTION
Based on realization that `amtDeltas[cycleX].nextCycle` will never be updated when `cycleX` is finished. That means that when `cycleX` is collected, value of its `nextCycle` is final and can be safely consumed and deleted.

When a receiver has `amtDelta` set for the first time ever, let's say that for `cycleY`, `amtDeltas[cycleY].thisCycle` is set, never `amtDeltas[cycleY-1].nextCycle`, so the latter doesn't need to be ever analyzed.

This PR reduces two SLOADs to one for each collected cycle.