### PR TITLE
Drop storage of weights list properties

### DIFF
--- a/src/test/Pool.t.sol
+++ b/src/test/Pool.t.sol
@@ -145,6 +145,15 @@ abstract contract PoolTest is PoolUserUtils {
         collect(receiver, 99);
     }
 
+    function testCollectableRevertsIfInvalidCurrReceivers() public {
+        updateSender(sender, 0, 0, 0, 0, weights(receiver, 1));
+        try sender.collectable(weights(receiver, 2)) {
+            assertTrue(false, "Collectable hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Invalid current receivers", "Invalid collectable revert reason");
+        }
+    }
+
     function testAllowsToppingUpWhileSending() public {
         updateSender(sender, 0, 100, 10, 0, weights(receiver, 1));
         warpBy(6);
@@ -341,13 +350,31 @@ abstract contract PoolTest is PoolUserUtils {
             pool.AMT_PER_SEC_UNCHANGED(),
             0,
             weights(receiver, 1),
-            weights()
+            weights(receiver, 1)
         );
         assertWithdrawable(sender, 0);
         assertBalance(sender, expectedBalance);
         warpToCycleEnd();
         // Receiver had 4 seconds paying 1 per second
         collect(receiver, 4);
+    }
+
+    function testWithdrawableRevertsIfInvalidCurrReceivers() public {
+        updateSender(sender, 0, 0, 0, 0, weights(receiver, 1));
+        try sender.withdrawable(weights(receiver, 2)) {
+            assertTrue(false, "Withdrawable hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Invalid current receivers", "Invalid withdrawable revert reason");
+        }
+    }
+
+    function testWithdrawableSubSenderRevertsIfInvalidCurrReceivers() public {
+        updateSubSender(sender, SUB_SENDER_1, 0, 0, 0, weights(receiver, 1));
+        try sender.withdrawableSubSender(SUB_SENDER_1, weights(receiver, 2)) {
+            assertTrue(false, "Withdrawable hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Invalid current receivers", "Invalid withdrawable revert reason");
+        }
     }
 
     function testAnybodyCanCallCollect() public {

--- a/src/test/User.t.sol
+++ b/src/test/User.t.sol
@@ -50,8 +50,12 @@ abstract contract PoolUser {
         return getPool().collect(receiverAddr, currReceivers);
     }
 
-    function collectable() public view returns (uint128 collected, uint128 dripped) {
-        return getPool().collectable(address(this));
+    function collectable(ReceiverWeight[] calldata currReceivers)
+        public
+        view
+        returns (uint128 collected, uint128 dripped)
+    {
+        return getPool().collectable(address(this), currReceivers);
     }
 
     function flushableCycles() public view returns (uint64 flushable) {
@@ -62,12 +66,16 @@ abstract contract PoolUser {
         return getPool().flushCycles(address(this), maxCycles);
     }
 
-    function withdrawable() public view returns (uint128) {
-        return getPool().withdrawable(address(this));
+    function withdrawable(ReceiverWeight[] calldata currReceivers) public view returns (uint128) {
+        return getPool().withdrawable(address(this), currReceivers);
     }
 
-    function withdrawableSubSender(uint256 subSenderId) public view returns (uint128) {
-        return getPool().withdrawableSubSender(address(this), subSenderId);
+    function withdrawableSubSender(uint256 subSenderId, ReceiverWeight[] calldata currReceivers)
+        public
+        view
+        returns (uint128)
+    {
+        return getPool().withdrawableSubSender(address(this), subSenderId, currReceivers);
     }
 
     function getAmtPerSec() public view returns (uint128) {

--- a/src/test/UserUtils.t.sol
+++ b/src/test/UserUtils.t.sol
@@ -114,7 +114,8 @@ abstract contract PoolUserUtils is DSTest {
     }
 
     function assertWithdrawable(PoolUser user, uint128 expected) internal {
-        assertEq(user.withdrawable(), expected, "Invalid withdrawable");
+        uint128 actual = user.withdrawable(getCurrWeights(user));
+        assertEq(actual, expected, "Invalid withdrawable");
     }
 
     function changeBalance(
@@ -133,7 +134,7 @@ abstract contract PoolUserUtils is DSTest {
     }
 
     function setAmtPerSec(PoolUser user, uint128 amtPerSec) internal {
-        uint128 withdrawable = user.withdrawable();
+        uint128 withdrawable = user.withdrawable(getCurrWeights(user));
         updateSender(
             user,
             withdrawable,
@@ -145,7 +146,7 @@ abstract contract PoolUserUtils is DSTest {
     }
 
     function setReceivers(PoolUser user, ReceiverWeight[] memory newReceivers) internal {
-        uint128 withdrawable = user.withdrawable();
+        uint128 withdrawable = user.withdrawable(getCurrWeights(user));
         updateSender(
             user,
             withdrawable,
@@ -221,7 +222,9 @@ abstract contract PoolUserUtils is DSTest {
         uint256 subSenderId,
         uint128 expected
     ) internal {
-        assertEq(user.withdrawableSubSender(subSenderId), expected, "Invalid withdrawable");
+        ReceiverWeight[] memory receivers = getCurrSubSenderWeights(user, subSenderId);
+        uint128 actual = user.withdrawableSubSender(subSenderId, receivers);
+        assertEq(actual, expected, "Invalid withdrawable");
     }
 
     function assertSubSenderReceivers(
@@ -299,7 +302,7 @@ abstract contract PoolUserUtils is DSTest {
         uint128 expectedCollected,
         uint128 expectedDripped
     ) internal {
-        (uint128 actualCollected, uint128 actualDripped) = user.collectable();
+        (uint128 actualCollected, uint128 actualDripped) = user.collectable(getCurrWeights(user));
         assertEq(actualCollected, expectedCollected, "Invalid collectable");
         assertEq(actualDripped, expectedDripped, "Invalid drippable");
     }


### PR DESCRIPTION
Depends on https://github.com/radicle-dev/radicle-streaming/pull/41. Drops storage of metadata about the receivers list, which can be cheaply extracted from calldata.