### PR TITLE
Switch receivers configuration from weights to amtPerSec

### DIFF
--- a/src/DaiPool.sol
+++ b/src/DaiPool.sol
@@ -47,7 +47,6 @@ contract DaiPool is ERC20Pool {
     function updateSenderAndPermit(
         uint128 topUpAmt,
         uint128 withdraw,
-        uint128 amtPerSec,
         uint32 dripsFraction,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers,
@@ -61,8 +60,7 @@ contract DaiPool is ERC20Pool {
         )
     {
         permit(permitArgs);
-        return
-            updateSender(topUpAmt, withdraw, amtPerSec, dripsFraction, currReceivers, newReceivers);
+        return updateSender(topUpAmt, withdraw, dripsFraction, currReceivers, newReceivers);
     }
 
     /// @notice Updates all the parameters of a sub-sender of the sender of the message
@@ -73,21 +71,12 @@ contract DaiPool is ERC20Pool {
         uint256 subSenderId,
         uint128 topUpAmt,
         uint128 withdraw,
-        uint128 amtPerSec,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers,
         PermitArgs calldata permitArgs
     ) public returns (uint128 withdrawn) {
         permit(permitArgs);
-        return
-            updateSubSender(
-                subSenderId,
-                topUpAmt,
-                withdraw,
-                amtPerSec,
-                currReceivers,
-                newReceivers
-            );
+        return updateSubSender(subSenderId, topUpAmt, withdraw, currReceivers, newReceivers);
     }
 
     function permit(PermitArgs calldata permitArgs) internal {

--- a/src/DaiPool.sol
+++ b/src/DaiPool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.7;
 
-import {ERC20Pool, ReceiverWeight} from "./ERC20Pool.sol";
+import {ERC20Pool, Receiver} from "./ERC20Pool.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 
 interface IDai is IERC20 {
@@ -48,8 +48,8 @@ contract DaiPool is ERC20Pool {
         uint128 topUpAmt,
         uint128 withdraw,
         uint32 dripsFraction,
-        ReceiverWeight[] calldata currReceivers,
-        ReceiverWeight[] calldata newReceivers,
+        Receiver[] calldata currReceivers,
+        Receiver[] calldata newReceivers,
         PermitArgs calldata permitArgs
     )
         public
@@ -71,8 +71,8 @@ contract DaiPool is ERC20Pool {
         uint256 subSenderId,
         uint128 topUpAmt,
         uint128 withdraw,
-        ReceiverWeight[] calldata currReceivers,
-        ReceiverWeight[] calldata newReceivers,
+        Receiver[] calldata currReceivers,
+        Receiver[] calldata newReceivers,
         PermitArgs calldata permitArgs
     ) public returns (uint128 withdrawn) {
         permit(permitArgs);

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -41,8 +41,6 @@ contract ERC20Pool is Pool {
     /// @param topUpAmt The topped up amount
     /// @param withdraw The amount to be withdrawn, must not be higher than available funds.
     /// Can be `WITHDRAW_ALL` to withdraw everything.
-    /// @param amtPerSec The target amount to be sent every second.
-    /// Can be `AMT_PER_SEC_UNCHANGED` to keep the amount unchanged.
     /// @param dripsFraction The fraction of received funds to be dripped.
     /// Must be a value from 0 to `DRIPS_FRACTION_MAX` inclusively,
     /// where 0 means no dripping and `DRIPS_FRACTION_MAX` dripping everything.
@@ -58,7 +56,6 @@ contract ERC20Pool is Pool {
     function updateSender(
         uint128 topUpAmt,
         uint128 withdraw,
-        uint128 amtPerSec,
         uint32 dripsFraction,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
@@ -76,7 +73,6 @@ contract ERC20Pool is Pool {
                 msg.sender,
                 topUpAmt,
                 withdraw,
-                amtPerSec,
                 dripsFraction,
                 currReceivers,
                 newReceivers
@@ -90,7 +86,6 @@ contract ERC20Pool is Pool {
         uint256 subSenderId,
         uint128 topUpAmt,
         uint128 withdraw,
-        uint128 amtPerSec,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
     ) public payable returns (uint128 withdrawn) {
@@ -101,7 +96,6 @@ contract ERC20Pool is Pool {
                 subSenderId,
                 topUpAmt,
                 withdraw,
-                amtPerSec,
                 currReceivers,
                 newReceivers
             );

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.7;
 
-import {Pool, ReceiverWeight} from "./Pool.sol";
+import {Pool, Receiver} from "./Pool.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 
 /// @notice Funding pool contract for any ERC-20 token.
@@ -26,29 +26,15 @@ contract ERC20Pool is Pool {
     /// Tops up and withdraws unsent funds from the balance of the sender.
     /// The sender must first grant the contract a sufficient allowance to top up.
     /// Sends the withdrawn funds to the sender of the message.
-    ///
-    /// Sets the target amount sent every second from the sender of the message.
-    /// Every second this amount is rounded down to the closest multiple of the sum of the weights
-    /// of the receivers and split between them proportionally to their weights.
-    /// Each receiver then receives their part from the sender's balance.
-    /// If set to zero, stops funding.
-    ///
-    /// Sets the weight of the provided receivers of the sender of the message.
-    /// The weight regulates the share of the amount sent every second
-    /// that each of the sender's receivers get.
-    /// Setting a non-zero weight for a new receiver adds it to the set of the sender's receivers.
-    /// Setting zero as the weight for a receiver removes it from the set of the sender's receivers.
     /// @param topUpAmt The topped up amount
     /// @param withdraw The amount to be withdrawn, must not be higher than available funds.
     /// Can be `WITHDRAW_ALL` to withdraw everything.
     /// @param dripsFraction The fraction of received funds to be dripped.
-    /// Must be a value from 0 to `DRIPS_FRACTION_MAX` inclusively,
-    /// where 0 means no dripping and `DRIPS_FRACTION_MAX` dripping everything.
-    /// @param currReceivers The list of the user's receivers and their weights,
-    /// which is currently in use.
+    /// Must be a value from 0 to `MAX_DRIPS_FRACTION` inclusively,
+    /// where 0 means no dripping and `MAX_DRIPS_FRACTION` dripping everything.
+    /// @param currReceivers The list of the user's receivers which is currently in use.
     /// If this function is called for the first time for the user, should be an empty array.
-    /// @param newReceivers The list of the user's receivers and their weights,
-    /// which shall be in use after this function is called.
+    /// @param newReceivers The new list of the user's receivers.
     /// @return withdrawn The actually withdrawn amount.
     /// Equal to `withdrawAmt` unless `WITHDRAW_ALL` is used.
     /// @return collected The collected amount
@@ -57,8 +43,8 @@ contract ERC20Pool is Pool {
         uint128 topUpAmt,
         uint128 withdraw,
         uint32 dripsFraction,
-        ReceiverWeight[] calldata currReceivers,
-        ReceiverWeight[] calldata newReceivers
+        Receiver[] calldata currReceivers,
+        Receiver[] calldata newReceivers
     )
         public
         returns (
@@ -86,8 +72,8 @@ contract ERC20Pool is Pool {
         uint256 subSenderId,
         uint128 topUpAmt,
         uint128 withdraw,
-        ReceiverWeight[] calldata currReceivers,
-        ReceiverWeight[] calldata newReceivers
+        Receiver[] calldata currReceivers,
+        Receiver[] calldata newReceivers
     ) public payable returns (uint128 withdrawn) {
         _transferToContract(msg.sender, topUpAmt);
         return

--- a/src/EthPool.sol
+++ b/src/EthPool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.7;
 
-import {Pool, ReceiverWeight} from "./Pool.sol";
+import {Pool, Receiver} from "./Pool.sol";
 
 /// @notice Funding pool contract for Ether.
 /// See the base `Pool` contract docs for more details.
@@ -20,28 +20,14 @@ contract EthPool is Pool {
     /// Tops up and withdraws unsent funds from the balance of the sender.
     /// Tops up with the amount in the message.
     /// Sends the withdrawn funds to the sender of the message.
-    ///
-    /// Sets the target amount sent every second from the sender of the message.
-    /// Every second this amount is rounded down to the closest multiple of the sum of the weights
-    /// of the receivers and split between them proportionally to their weights.
-    /// Each receiver then receives their part from the sender's balance.
-    /// If set to zero, stops funding.
-    ///
-    /// Sets the weight of the provided receivers of the sender of the message.
-    /// The weight regulates the share of the amount sent every second
-    /// that each of the sender's receivers get.
-    /// Setting a non-zero weight for a new receiver adds it to the set of the sender's receivers.
-    /// Setting zero as the weight for a receiver removes it from the set of the sender's receivers.
     /// @param withdraw The amount to be withdrawn, must not be higher than available funds.
     /// Can be `WITHDRAW_ALL` to withdraw everything.
     /// @param dripsFraction The fraction of received funds to be dripped.
-    /// Must be a value from 0 to `DRIPS_FRACTION_MAX` inclusively,
-    /// where 0 means no dripping and `DRIPS_FRACTION_MAX` dripping everything.
-    /// @param currReceivers The list of the user's receivers and their weights,
-    /// which is currently in use.
+    /// Must be a value from 0 to `MAX_DRIPS_FRACTION` inclusively,
+    /// where 0 means no dripping and `MAX_DRIPS_FRACTION` dripping everything.
+    /// @param currReceivers The list of the user's receivers which is currently in use.
     /// If this function is called for the first time for the user, should be an empty array.
-    /// @param newReceivers The list of the user's receivers and their weights,
-    /// which shall be in use after this function is called.
+    /// @param newReceivers The new list of the user's receivers.
     /// @return withdrawn The actually withdrawn amount.
     /// Equal to `withdrawAmt` unless `WITHDRAW_ALL` is used.
     /// @return collected The collected amount
@@ -49,8 +35,8 @@ contract EthPool is Pool {
     function updateSender(
         uint128 withdraw,
         uint32 dripsFraction,
-        ReceiverWeight[] calldata currReceivers,
-        ReceiverWeight[] calldata newReceivers
+        Receiver[] calldata currReceivers,
+        Receiver[] calldata newReceivers
     )
         public
         payable
@@ -77,8 +63,8 @@ contract EthPool is Pool {
     function updateSubSender(
         uint256 subSenderId,
         uint128 withdraw,
-        ReceiverWeight[] calldata currReceivers,
-        ReceiverWeight[] calldata newReceivers
+        Receiver[] calldata currReceivers,
+        Receiver[] calldata newReceivers
     ) public payable returns (uint128 withdrawn) {
         return
             _updateSubSenderInternal(

--- a/src/EthPool.sol
+++ b/src/EthPool.sol
@@ -34,8 +34,6 @@ contract EthPool is Pool {
     /// Setting zero as the weight for a receiver removes it from the set of the sender's receivers.
     /// @param withdraw The amount to be withdrawn, must not be higher than available funds.
     /// Can be `WITHDRAW_ALL` to withdraw everything.
-    /// @param amtPerSec The target amount to be sent every second.
-    /// Can be `AMT_PER_SEC_UNCHANGED` to keep the amount unchanged.
     /// @param dripsFraction The fraction of received funds to be dripped.
     /// Must be a value from 0 to `DRIPS_FRACTION_MAX` inclusively,
     /// where 0 means no dripping and `DRIPS_FRACTION_MAX` dripping everything.
@@ -50,7 +48,6 @@ contract EthPool is Pool {
     /// @return dripped The amount dripped to the user's receivers
     function updateSender(
         uint128 withdraw,
-        uint128 amtPerSec,
         uint32 dripsFraction,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
@@ -68,7 +65,6 @@ contract EthPool is Pool {
                 msg.sender,
                 uint128(msg.value),
                 withdraw,
-                amtPerSec,
                 dripsFraction,
                 currReceivers,
                 newReceivers
@@ -81,7 +77,6 @@ contract EthPool is Pool {
     function updateSubSender(
         uint256 subSenderId,
         uint128 withdraw,
-        uint128 amtPerSec,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
     ) public payable returns (uint128 withdrawn) {
@@ -91,7 +86,6 @@ contract EthPool is Pool {
                 subSenderId,
                 uint128(msg.value),
                 withdraw,
-                amtPerSec,
                 currReceivers,
                 newReceivers
             );

--- a/src/test/Pool.t.sol
+++ b/src/test/Pool.t.sol
@@ -47,7 +47,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsSendingToASingleReceiver() public {
-        updateSender(sender, 0, 100, 1, 0, weights(receiver, 1));
+        updateSender(sender, 0, 100, 0, weights(receiver, 1));
         warpBy(15);
         // Sender had 15 seconds paying 1 per second
         changeBalance(sender, 85, 0);
@@ -61,7 +61,7 @@ abstract contract PoolTest is PoolUserUtils {
     {
         uint128 time = (cycles / 10) * pool.cycleSecs() + (timeInCycle % pool.cycleSecs());
         uint128 balance = 25 * pool.cycleSecs() + 256;
-        updateSender(sender, 0, balance, 1, 0, weights(receiver, 1));
+        updateSender(sender, 0, balance, 0, weights(receiver, 1));
         warpBy(time);
         // Sender had `time` seconds paying 1 per second
         changeBalance(sender, balance - time, 0);
@@ -71,7 +71,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsSendingToMultipleReceivers() public {
-        updateSender(sender, 0, 6, 3, 0, weights(receiver1, 1, receiver2, 2));
+        updateSender(sender, 0, 6, 0, weights(receiver1, 1, receiver2, 2));
         warpToCycleEnd();
         // Sender had 2 seconds paying 1 per second
         collect(receiver1, 2);
@@ -80,7 +80,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testSendsSomeFundsFromASingleSenderToTwoReceivers() public {
-        updateSender(sender, 0, 100, 2, 0, weights(receiver1, 1, receiver2, 1));
+        updateSender(sender, 0, 100, 0, weights(receiver1, 1, receiver2, 1));
         warpBy(14);
         // Sender had 14 seconds paying 2 per second
         changeBalance(sender, 72, 0);
@@ -92,9 +92,9 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testSendsSomeFundsFromATwoSendersToASingleReceiver() public {
-        updateSender(sender1, 0, 100, 1, 0, weights(receiver, 1));
+        updateSender(sender1, 0, 100, 0, weights(receiver, 1));
         warpBy(2);
-        updateSender(sender2, 0, 100, 2, 0, weights(receiver, 1));
+        updateSender(sender2, 0, 100, 0, weights(receiver, 2));
         warpBy(15);
         // Sender1 had 17 seconds paying 1 per second
         changeBalance(sender1, 83, 0);
@@ -110,7 +110,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsCollectingFundsWhileTheyAreBeingSent() public {
-        updateSender(sender, 0, pool.cycleSecs() + 10, 1, 0, weights(receiver, 1));
+        updateSender(sender, 0, pool.cycleSecs() + 10, 0, weights(receiver, 1));
         warpToCycleEnd();
         // Receiver had cycleSecs seconds paying 1 per second
         collect(receiver, pool.cycleSecs());
@@ -123,7 +123,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testCollectRevertsIfInvalidCurrReceivers() public {
-        updateSender(sender, 0, 0, 0, 0, weights(receiver, 1));
+        updateSender(sender, 0, 0, 0, weights(receiver, 1));
         try sender.collect(address(sender), weights(receiver, 2)) {
             assertTrue(false, "Collect hasn't reverted");
         } catch Error(string memory reason) {
@@ -132,7 +132,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testSendsFundsUntilTheyRunOut() public {
-        updateSender(sender, 0, 100, 9, 0, weights(receiver, 1));
+        updateSender(sender, 0, 100, 0, weights(receiver, 9));
         warpBy(10);
         // Sender had 10 seconds paying 9 per second, funds are about to run out
         assertWithdrawable(sender, 10);
@@ -146,7 +146,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testCollectableRevertsIfInvalidCurrReceivers() public {
-        updateSender(sender, 0, 0, 0, 0, weights(receiver, 1));
+        updateSender(sender, 0, 0, 0, weights(receiver, 1));
         try sender.collectable(weights(receiver, 2)) {
             assertTrue(false, "Collectable hasn't reverted");
         } catch Error(string memory reason) {
@@ -155,7 +155,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsToppingUpWhileSending() public {
-        updateSender(sender, 0, 100, 10, 0, weights(receiver, 1));
+        updateSender(sender, 0, 100, 0, weights(receiver, 10));
         warpBy(6);
         // Sender had 6 seconds paying 10 per second
         changeBalance(sender, 40, 60);
@@ -168,7 +168,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsToppingUpAfterFundsRunOut() public {
-        updateSender(sender, 0, 100, 10, 0, weights(receiver, 1));
+        updateSender(sender, 0, 100, 0, weights(receiver, 10));
         warpBy(10);
         // Sender had 10 seconds paying 10 per second
         assertWithdrawable(sender, 0);
@@ -186,7 +186,7 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testAllowsSendingWhichShouldEndAfterMaxTimestamp() public {
         uint128 balance = type(uint64).max + uint128(6);
-        updateSender(sender, 0, balance, 1, 0, weights(receiver, 1));
+        updateSender(sender, 0, balance, 0, weights(receiver, 1));
         warpBy(10);
         // Sender had 10 seconds paying 1 per second
         changeBalance(sender, balance - 10, 0);
@@ -195,56 +195,24 @@ abstract contract PoolTest is PoolUserUtils {
         collect(receiver, 10);
     }
 
-    function testAllowsChangingAmountPerSecondWhileSending() public {
-        updateSender(sender, 0, 100, 10, 0, weights(receiver, 1));
-        warpBy(4);
-        setAmtPerSec(sender, 9);
-        warpBy(4);
-        // Sender had 4 seconds paying 10 per second and 4 seconds paying 9 per second
-        changeBalance(sender, 24, 0);
-        warpToCycleEnd();
-        // Receiver had 4 seconds paying 10 per second and 4 seconds paying 9 per second
-        collect(receiver, 76);
-    }
-
     function testAllowsSenderUpdateWithTopUpAndWithdrawal() public {
-        sender.updateSender(10, 3, 0, 0, weights(), weights());
+        sender.updateSender(10, 3, 0, weights(), weights());
         assertWithdrawable(sender, 7);
     }
 
     function testAllowsNoSenderUpdate() public {
-        updateSender(sender, 0, 6, 3, 0, weights(receiver, 1));
+        updateSender(sender, 0, 6, 0, weights(receiver, 3));
         warpBy(1);
         // Sender had 1 second paying 3 per second
-        updateSender(sender, 3, 3, pool.AMT_PER_SEC_UNCHANGED(), 0, weights(receiver, 1));
+        updateSender(sender, 3, 3, 0, weights(receiver, 1));
         warpToCycleEnd();
         collect(receiver, 6);
     }
 
-    function testSendsAmountPerSecondRoundedDownToAMultipleOfWeightsSum() public {
-        updateSender(sender, 0, 100, 9, 0, weights(receiver, 5));
-        warpBy(5);
-        // Sender had 5 seconds paying 5 per second
-        changeBalance(sender, 75, 0);
-        warpToCycleEnd();
-        // Receiver had 5 seconds paying 5 per second
-        collect(receiver, 25);
-    }
-
-    function testSendsNothingIfAmountPerSecondIsSmallerThanWeightsSum() public {
-        updateSender(sender, 0, 100, 4, 0, weights(receiver, 5));
-        warpBy(5);
-        // Sender had 0 paying seconds
-        changeBalance(sender, 100, 0);
-        warpToCycleEnd();
-        // Receiver had 0 paying seconds
-        collect(receiver, 0);
-    }
-
     function testAllowsChangingReceiverWeightsWhileSending() public {
-        updateSender(sender, 0, 100, 12, 0, weights(receiver1, 1, receiver2, 1));
+        updateSender(sender, 0, 100, 0, weights(receiver1, 6, receiver2, 6));
         warpBy(3);
-        setReceivers(sender, weights(receiver1, 1, receiver2, 2));
+        setReceivers(sender, weights(receiver1, 4, receiver2, 8));
         warpBy(4);
         // Sender had 7 seconds paying 12 per second
         changeBalance(sender, 16, 0);
@@ -256,9 +224,9 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsRemovingReceiversWhileSending() public {
-        updateSender(sender, 0, 100, 10, 0, weights(receiver1, 1, receiver2, 1));
+        updateSender(sender, 0, 100, 0, weights(receiver1, 5, receiver2, 5));
         warpBy(3);
-        setReceivers(sender, weights(receiver2, 1));
+        setReceivers(sender, weights(receiver2, 10));
         warpBy(4);
         setReceivers(sender, weights());
         warpBy(10);
@@ -269,24 +237,6 @@ abstract contract PoolTest is PoolUserUtils {
         collect(receiver1, 15);
         // Receiver2 had 3 seconds paying 5 per second and 4 seconds paying 10 per second
         collect(receiver2, 55);
-    }
-
-    function testLimitsTheTotalWeightsSum() public {
-        setReceivers(sender, weights(receiver, pool.SENDER_WEIGHTS_SUM_MAX()));
-        assertSetReceiversReverts(
-            sender,
-            weights(receiver, pool.SENDER_WEIGHTS_SUM_MAX() + 1),
-            "Too much total receivers weight"
-        );
-    }
-
-    function testLimitsTheOverflowingTotalWeightsSum() public {
-        setReceivers(sender, weights(receiver1, 1));
-        assertSetReceiversReverts(
-            sender,
-            weights(receiver2, type(uint32).max),
-            "Too much total receivers weight"
-        );
     }
 
     function testLimitsTheTotalReceiversCount() public {
@@ -303,8 +253,19 @@ abstract contract PoolTest is PoolUserUtils {
         assertSetReceiversReverts(sender, receiversBad, "Too many receivers");
     }
 
+    function testRejectsOverflowingTotalAmtPerSec() public {
+        ReceiverWeight[] memory receiversGood = weights(receiver1, type(uint128).max);
+        ReceiverWeight[] memory receiversBad = weights(receiver1, type(uint128).max, receiver2, 1);
+        updateSender(sender, 0, 0, 0, receiversGood);
+        try sender.updateSender(0, 0, 0, receiversGood, receiversBad) {
+            assertTrue(false, "Sender update hasn't reverted");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Total amtPerSec too high", "Invalid sender update revert reason");
+        }
+    }
+
     function testRejectsZeroWeightReceivers() public {
-        assertSetReceiversReverts(sender, weights(receiver, 0), "Receiver weight zero");
+        assertSetReceiversReverts(sender, weights(receiver, 0), "Receiver amtPerSec is zero");
     }
 
     function testRejectsUnsortedReceivers() public {
@@ -320,8 +281,8 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testUpdateSenderRevertsIfInvalidCurrReceivers() public {
-        updateSender(sender, 0, 0, 0, 0, weights(receiver, 1));
-        try sender.updateSender(0, 0, 0, 0, weights(receiver, 2), weights()) {
+        updateSender(sender, 0, 0, 0, weights(receiver, 1));
+        try sender.updateSender(0, 0, 0, weights(receiver, 2), weights()) {
             assertTrue(false, "Sender update hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, "Invalid current receivers", "Invalid sender update revert reason");
@@ -329,7 +290,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsAnAddressToBeASenderAndAReceiverIndependently() public {
-        updateSender(sender, 0, 10, 10, 0, weights(sender, 10));
+        updateSender(sender, 0, 10, 0, weights(sender, 10));
         warpBy(1);
         // Sender had 1 second paying 10 per second
         assertWithdrawable(sender, 0);
@@ -339,19 +300,12 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsWithdrawalOfAllFunds() public {
-        updateSender(sender, 0, 10, 1, 0, weights(receiver, 1));
+        updateSender(sender, 0, 10, 0, weights(receiver, 1));
         warpBy(4);
         // Sender had 4 second paying 1 per second
         assertWithdrawable(sender, 6);
         uint256 expectedBalance = sender.balance() + 6;
-        sender.updateSender(
-            0,
-            pool.WITHDRAW_ALL(),
-            pool.AMT_PER_SEC_UNCHANGED(),
-            0,
-            weights(receiver, 1),
-            weights(receiver, 1)
-        );
+        sender.updateSender(0, pool.WITHDRAW_ALL(), 0, weights(receiver, 1), weights(receiver, 1));
         assertWithdrawable(sender, 0);
         assertBalance(sender, expectedBalance);
         warpToCycleEnd();
@@ -360,7 +314,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testWithdrawableRevertsIfInvalidCurrReceivers() public {
-        updateSender(sender, 0, 0, 0, 0, weights(receiver, 1));
+        updateSender(sender, 0, 0, 0, weights(receiver, 1));
         try sender.withdrawable(weights(receiver, 2)) {
             assertTrue(false, "Withdrawable hasn't reverted");
         } catch Error(string memory reason) {
@@ -369,7 +323,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testWithdrawableSubSenderRevertsIfInvalidCurrReceivers() public {
-        updateSubSender(sender, SUB_SENDER_1, 0, 0, 0, weights(receiver, 1));
+        updateSubSender(sender, SUB_SENDER_1, 0, 0, weights(receiver, 1));
         try sender.withdrawableSubSender(SUB_SENDER_1, weights(receiver, 2)) {
             assertTrue(false, "Withdrawable hasn't reverted");
         } catch Error(string memory reason) {
@@ -378,16 +332,16 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAnybodyCanCallCollect() public {
-        updateSender(sender1, 0, 10, 10, 0, weights(receiver, 1));
+        updateSender(sender1, 0, 10, 0, weights(receiver, 10));
         warpToCycleEnd();
         // Receiver had 1 second paying 10 per second
         collect(sender2, receiver, 10);
     }
 
     function testSenderAndSubSenderAreIndependent() public {
-        updateSender(sender, 0, 5, 1, 0, weights(receiver1, 1));
+        updateSender(sender, 0, 5, 0, weights(receiver1, 1));
         warpBy(3);
-        updateSubSender(sender, SUB_SENDER_1, 0, 8, 3, weights(receiver1, 2, receiver2, 1));
+        updateSubSender(sender, SUB_SENDER_1, 0, 8, weights(receiver1, 2, receiver2, 1));
         warpBy(1);
         // Sender had 4 seconds paying 1 per second
         changeBalance(sender, 1, 0);
@@ -402,9 +356,9 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testUserSubSendersAreIndependent() public {
-        updateSubSender(sender, SUB_SENDER_1, 0, 5, 1, weights(receiver1, 1));
+        updateSubSender(sender, SUB_SENDER_1, 0, 5, weights(receiver1, 1));
         warpBy(3);
-        updateSubSender(sender, SUB_SENDER_2, 0, 8, 3, weights(receiver1, 2, receiver2, 1));
+        updateSubSender(sender, SUB_SENDER_2, 0, 8, weights(receiver1, 2, receiver2, 1));
         warpBy(1);
         // Sender sub-sender1 had 4 seconds paying 1 per second
         changeBalanceSubSender(sender, SUB_SENDER_1, 1, 0);
@@ -419,9 +373,9 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testSubSendersOfDifferentUsersAreIndependent() public {
-        updateSubSender(sender1, SUB_SENDER_1, 0, 5, 1, weights(receiver1, 1));
+        updateSubSender(sender1, SUB_SENDER_1, 0, 5, weights(receiver1, 1));
         warpBy(3);
-        updateSubSender(sender2, SUB_SENDER_1, 0, 8, 3, weights(receiver1, 2, receiver2, 1));
+        updateSubSender(sender2, SUB_SENDER_1, 0, 8, weights(receiver1, 2, receiver2, 1));
         warpBy(1);
         // Sender1 sub-sender1 had 4 seconds paying 1 per second
         changeBalanceSubSender(sender1, SUB_SENDER_1, 1, 0);
@@ -437,8 +391,8 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testDripsFractionIsLimited() public {
         uint32 dripsFractionMax = sender.getDripsFractionMax();
-        updateSender(sender, 0, 0, 0, dripsFractionMax, weights());
-        try sender.updateSender(0, 0, 0, dripsFractionMax + 1, weights(), weights()) {
+        updateSender(sender, 0, 0, dripsFractionMax, weights());
+        try sender.updateSender(0, 0, dripsFractionMax + 1, weights(), weights()) {
             assertTrue(false, "Update senders hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, "Drip fraction too high", "Invalid update sender revert reason");
@@ -447,8 +401,8 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testCollectDrips() public {
         uint32 dripsFractionMax = sender.getDripsFractionMax();
-        updateSender(sender, 0, 10, 10, 0, weights(receiver1, 1));
-        updateSender(receiver1, 0, 0, 0, dripsFractionMax, weights(receiver2, 1));
+        updateSender(sender, 0, 10, 0, weights(receiver1, 10));
+        updateSender(receiver1, 0, 0, dripsFractionMax, weights(receiver2, 1));
         warpToCycleEnd();
         assertCollectable(receiver2, 0);
         // Receiver1 had 1 second paying 10 per second of which 10 is dripped
@@ -459,9 +413,9 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testCollectDripsFundsFromDrips() public {
         uint32 dripsFractionMax = sender.getDripsFractionMax();
-        updateSender(sender, 0, 10, 10, 0, weights(receiver1, 1));
-        updateSender(receiver1, 0, 0, 0, dripsFractionMax, weights(receiver2, 1));
-        updateSender(receiver2, 0, 0, 0, dripsFractionMax, weights(receiver3, 1));
+        updateSender(sender, 0, 10, 0, weights(receiver1, 10));
+        updateSender(receiver1, 0, 0, dripsFractionMax, weights(receiver2, 1));
+        updateSender(receiver2, 0, 0, dripsFractionMax, weights(receiver3, 1));
         warpToCycleEnd();
         assertCollectable(receiver2, 0);
         assertCollectable(receiver3, 0);
@@ -475,8 +429,8 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testCollectMixesStreamsAndDrips() public {
         uint32 dripsFractionMax = sender.getDripsFractionMax();
-        updateSender(sender, 0, 10, 10, 0, weights(receiver1, 1, receiver2, 1));
-        updateSender(receiver1, 0, 0, 0, dripsFractionMax, weights(receiver2, 1));
+        updateSender(sender, 0, 10, 0, weights(receiver1, 5, receiver2, 5));
+        updateSender(receiver1, 0, 0, dripsFractionMax, weights(receiver2, 1));
         warpToCycleEnd();
         // Receiver2 had 1 second paying 5 per second
         assertCollectable(receiver2, 5);
@@ -488,10 +442,9 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testCollectSplitsFundsBetweenReceiverAndDrips() public {
         uint32 dripsFractionMax = sender.getDripsFractionMax();
-        updateSender(sender, 0, 10, 10, 0, weights(receiver1, 1));
+        updateSender(sender, 0, 10, 0, weights(receiver1, 10));
         updateSender(
             receiver1,
-            0,
             0,
             0,
             (dripsFractionMax * 3) / 4,
@@ -511,11 +464,10 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testUpdateSenderCollects() public {
-        updateSender(sender1, 0, 10, 10, 0, weights(sender2, 1));
+        updateSender(sender1, 0, 10, 0, weights(sender2, 10));
         warpToCycleEnd();
         uint256 balanceOld = sender2.balance();
         (uint128 withdrawn, uint128 collected, uint128 dripped) = sender2.updateSender(
-            0,
             0,
             0,
             0,
@@ -531,13 +483,12 @@ abstract contract PoolTest is PoolUserUtils {
     function testUpdateSenderDrips() public {
         uint32 dripsFractionMax = sender.getDripsFractionMax();
         // Sender2 drips to receiver1
-        updateSender(sender2, 0, 0, 0, dripsFractionMax, weights(receiver1, 1));
-        updateSender(sender1, 0, 10, 10, 0, weights(sender2, 1));
+        updateSender(sender2, 0, 0, dripsFractionMax, weights(receiver1, 1));
+        updateSender(sender1, 0, 10, 0, weights(sender2, 10));
         warpToCycleEnd();
         uint256 balanceOld = sender2.balance();
         // New sender2 configuration, stops dripping to receiver1
         (uint128 withdrawn, uint128 collected, uint128 dripped) = sender2.updateSender(
-            0,
             0,
             0,
             0,
@@ -557,7 +508,7 @@ abstract contract PoolTest is PoolUserUtils {
         // Enough for 3 cycles
         uint128 amt = pool.cycleSecs() * 3;
         warpToCycleEnd();
-        updateSender(sender, 0, amt, 1, 0, weights(receiver, 1));
+        updateSender(sender, 0, amt, 0, weights(receiver, 1));
         warpToCycleEnd();
         warpToCycleEnd();
         warpToCycleEnd();
@@ -569,7 +520,7 @@ abstract contract PoolTest is PoolUserUtils {
         // Enough for 3 cycles
         uint128 amt = pool.cycleSecs() * 3;
         warpToCycleEnd();
-        updateSender(sender, 0, amt, 1, 0, weights(receiver, 1));
+        updateSender(sender, 0, amt, 0, weights(receiver, 1));
         warpToCycleEnd();
         warpToCycleEnd();
         warpToCycleEnd();

--- a/src/test/User.t.sol
+++ b/src/test/User.t.sol
@@ -10,10 +10,6 @@ abstract contract PoolUser {
 
     function balance() public view virtual returns (uint256);
 
-    function getAmtPerSecUnchanged() public view returns (uint128) {
-        return getPool().AMT_PER_SEC_UNCHANGED();
-    }
-
     function getDripsFractionMax() public view returns (uint32) {
         return getPool().DRIPS_FRACTION_MAX();
     }
@@ -21,7 +17,6 @@ abstract contract PoolUser {
     function updateSender(
         uint128 toppedUp,
         uint128 withdraw,
-        uint128 amtPerSec,
         uint32 dripsFraction,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
@@ -38,7 +33,6 @@ abstract contract PoolUser {
         uint256 subSenderId,
         uint128 toppedUp,
         uint128 withdraw,
-        uint128 amtPerSec,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
     ) public virtual returns (uint128 withdrawn);
@@ -76,14 +70,6 @@ abstract contract PoolUser {
         returns (uint128)
     {
         return getPool().withdrawableSubSender(address(this), subSenderId, currReceivers);
-    }
-
-    function getAmtPerSec() public view returns (uint128) {
-        return getPool().getAmtPerSec(address(this));
-    }
-
-    function getAmtPerSecSubSender(uint256 subSenderId) public view returns (uint128) {
-        return getPool().getAmtPerSecSubSender(address(this), subSenderId);
     }
 
     function getDripsFraction() public view returns (uint32) {
@@ -129,7 +115,6 @@ contract ERC20PoolUser is PoolUser {
     function updateSender(
         uint128 toppedUp,
         uint128 withdraw,
-        uint128 amtPerSec,
         uint32 dripsFraction,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
@@ -143,35 +128,18 @@ contract ERC20PoolUser is PoolUser {
         )
     {
         pool.erc20().approve(address(pool), toppedUp);
-        return
-            pool.updateSender(
-                toppedUp,
-                withdraw,
-                amtPerSec,
-                dripsFraction,
-                currReceivers,
-                newReceivers
-            );
+        return pool.updateSender(toppedUp, withdraw, dripsFraction, currReceivers, newReceivers);
     }
 
     function updateSubSender(
         uint256 subSenderId,
         uint128 toppedUp,
         uint128 withdraw,
-        uint128 amtPerSec,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
     ) public override returns (uint128 withdrawn) {
         pool.erc20().approve(address(pool), toppedUp);
-        return
-            pool.updateSubSender(
-                subSenderId,
-                toppedUp,
-                withdraw,
-                amtPerSec,
-                currReceivers,
-                newReceivers
-            );
+        return pool.updateSubSender(subSenderId, toppedUp, withdraw, currReceivers, newReceivers);
     }
 }
 
@@ -196,7 +164,6 @@ contract EthPoolUser is PoolUser {
     function updateSender(
         uint128 toppedUp,
         uint128 withdraw,
-        uint128 amtPerSec,
         uint32 dripsFraction,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
@@ -212,7 +179,6 @@ contract EthPoolUser is PoolUser {
         return
             pool.updateSender{value: toppedUp}(
                 withdraw,
-                amtPerSec,
                 dripsFraction,
                 currReceivers,
                 newReceivers
@@ -223,7 +189,6 @@ contract EthPoolUser is PoolUser {
         uint256 subSenderId,
         uint128 toppedUp,
         uint128 withdraw,
-        uint128 amtPerSec,
         ReceiverWeight[] calldata currReceivers,
         ReceiverWeight[] calldata newReceivers
     ) public override returns (uint128 withdrawn) {
@@ -231,7 +196,6 @@ contract EthPoolUser is PoolUser {
             pool.updateSubSender{value: toppedUp}(
                 subSenderId,
                 withdraw,
-                amtPerSec,
                 currReceivers,
                 newReceivers
             );


### PR DESCRIPTION
Depends on https://github.com/radicle-dev/radicle-streaming/pull/44.

This is a major shift in the pool API, drops the notion of weights in favor of plain amtPerSecs. This PR is divided into 2 commits and it's probably the best approach to view them one after another:
1. updates the logic and the tests in the most concise way
2. renames things and fixes comments without altering the logic

The gas usage of all calls to `updateSender` in all tests drops from 6,970,631 to 5,670,301 (19%).