### PR TITLE
Add setDripsReceiver

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.7;
 
-import {Pool, Receiver} from "./Pool.sol";
+import {DripsReceiver, Pool, Receiver} from "./Pool.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 
 /// @notice Funding pool contract for any ERC-20 token.
@@ -104,6 +104,20 @@ contract ERC20Pool is Pool {
         uint128 amt
     ) public {
         _giveFromSubSenderInternal(msg.sender, subSenderId, receiver, amt);
+    }
+
+    /// @notice Sets a new list of drips receivers of the sender of the message.
+    /// @param currReceivers The list of the user's drips receivers which is currently in use.
+    /// If this function is called for the first time for the user, should be an empty array.
+    /// @param newReceivers The new list of the user's drips receivers.
+    /// Must be sorted by the drips receivers' addresses, deduplicated and without 0 weights.
+    /// Each drips receiver will be getting `weight / TOTAL_DRIPS_WEIGHTS`
+    /// share of the funds collected by the user.
+    function setDripsReceivers(
+        DripsReceiver[] calldata currReceivers,
+        DripsReceiver[] calldata newReceivers
+    ) public {
+        _setDripsReceiversInternal(msg.sender, currReceivers, newReceivers);
     }
 
     function _transfer(address userAddr, int128 amt) internal override {

--- a/src/EthPool.sol
+++ b/src/EthPool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.7;
 
-import {Pool, Receiver} from "./Pool.sol";
+import {DripsReceiver, Pool, Receiver} from "./Pool.sol";
 
 /// @notice Funding pool contract for Ether.
 /// See the base `Pool` contract docs for more details.
@@ -90,6 +90,20 @@ contract EthPool is Pool {
     /// @param receiver The receiver
     function giveFromSubSender(uint256 subSenderId, address receiver) public payable {
         _giveFromSubSenderInternal(msg.sender, subSenderId, receiver, uint128(msg.value));
+    }
+
+    /// @notice Sets a new list of drips receivers of the sender of the message.
+    /// @param currReceivers The list of the user's drips receivers which is currently in use.
+    /// If this function is called for the first time for the user, should be an empty array.
+    /// @param newReceivers The new list of the user's drips receivers.
+    /// Must be sorted by the drips receivers' addresses, deduplicated and without 0 weights.
+    /// Each drips receiver will be getting `weight / TOTAL_DRIPS_WEIGHTS`
+    /// share of the funds collected by the user.
+    function setDripsReceivers(
+        DripsReceiver[] calldata currReceivers,
+        DripsReceiver[] calldata newReceivers
+    ) public {
+        _setDripsReceiversInternal(msg.sender, currReceivers, newReceivers);
     }
 
     function _transfer(address userAddr, int128 amt) internal override {


### PR DESCRIPTION
Depends on https://github.com/radicle-dev/radicle-streaming/pull/52. This is the first PR for making the drips configuration independent from the sender's receivers list. It allows storing the drips receivers, but they aren't used anywhere yet.