### PR TITLE
Use drips receivers

### DIFF
--- a/src/DaiPool.sol
+++ b/src/DaiPool.sol
@@ -51,14 +51,7 @@ contract DaiPool is ERC20Pool {
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers,
         PermitArgs calldata permitArgs
-    )
-        public
-        returns (
-            uint128 withdrawn,
-            uint128 collected,
-            uint128 dripped
-        )
-    {
+    ) public returns (uint128 withdrawn) {
         permit(permitArgs);
         return updateSender(topUpAmt, withdraw, dripsFraction, currReceivers, newReceivers);
     }

--- a/src/DaiPool.sol
+++ b/src/DaiPool.sol
@@ -47,13 +47,12 @@ contract DaiPool is ERC20Pool {
     function updateSenderAndPermit(
         uint128 topUpAmt,
         uint128 withdraw,
-        uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers,
         PermitArgs calldata permitArgs
     ) public returns (uint128 withdrawn) {
         permit(permitArgs);
-        return updateSender(topUpAmt, withdraw, dripsFraction, currReceivers, newReceivers);
+        return updateSender(topUpAmt, withdraw, currReceivers, newReceivers);
     }
 
     /// @notice Updates all the parameters of a sub-sender of the sender of the message

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -35,24 +35,16 @@ contract ERC20Pool is Pool {
     /// @param currReceivers The list of the user's receivers which is currently in use.
     /// If this function is called for the first time for the user, should be an empty array.
     /// @param newReceivers The new list of the user's receivers.
+    /// Must be sorted by the receivers' addresses, deduplicated and without 0 amtPerSecs.
     /// @return withdrawn The actually withdrawn amount.
     /// Equal to `withdrawAmt` unless `WITHDRAW_ALL` is used.
-    /// @return collected The collected amount
-    /// @return dripped The amount dripped to the user's receivers
     function updateSender(
         uint128 topUpAmt,
         uint128 withdraw,
         uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
-    )
-        public
-        returns (
-            uint128 withdrawn,
-            uint128 collected,
-            uint128 dripped
-        )
-    {
+    ) public returns (uint128 withdrawn) {
         return
             _updateSenderInternal(
                 msg.sender,

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -29,9 +29,6 @@ contract ERC20Pool is Pool {
     /// @param topUpAmt The topped up amount
     /// @param withdraw The amount to be withdrawn, must not be higher than available funds.
     /// Can be `WITHDRAW_ALL` to withdraw everything.
-    /// @param dripsFraction The fraction of received funds to be dripped.
-    /// Must be a value from 0 to `MAX_DRIPS_FRACTION` inclusively,
-    /// where 0 means no dripping and `MAX_DRIPS_FRACTION` dripping everything.
     /// @param currReceivers The list of the user's receivers which is currently in use.
     /// If this function is called for the first time for the user, should be an empty array.
     /// @param newReceivers The new list of the user's receivers.
@@ -41,19 +38,10 @@ contract ERC20Pool is Pool {
     function updateSender(
         uint128 topUpAmt,
         uint128 withdraw,
-        uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
     ) public returns (uint128 withdrawn) {
-        return
-            _updateSenderInternal(
-                msg.sender,
-                topUpAmt,
-                withdraw,
-                dripsFraction,
-                currReceivers,
-                newReceivers
-            );
+        return _updateSenderInternal(msg.sender, topUpAmt, withdraw, currReceivers, newReceivers);
     }
 
     /// @notice Updates all the parameters of a sub-sender of the sender of the message.

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -20,8 +20,7 @@ contract ERC20Pool is Pool {
         erc20 = _erc20;
     }
 
-    /// @notice Collects received funds and updates all the sender parameters
-    //// of the sender of the message.
+    /// @notice Updates all the sender parameters of the sender of the message.
     ///
     /// Tops up and withdraws unsent funds from the balance of the sender.
     /// The sender must first grant the contract a sufficient allowance to top up.
@@ -86,18 +85,21 @@ contract ERC20Pool is Pool {
         _giveFromSubSenderInternal(msg.sender, subSenderId, receiver, amt);
     }
 
-    /// @notice Sets a new list of drips receivers of the sender of the message.
+    /// @notice Collects received funds and sets a new list of drips receivers
+    /// of the sender of the message.
     /// @param currReceivers The list of the user's drips receivers which is currently in use.
     /// If this function is called for the first time for the user, should be an empty array.
     /// @param newReceivers The new list of the user's drips receivers.
     /// Must be sorted by the drips receivers' addresses, deduplicated and without 0 weights.
     /// Each drips receiver will be getting `weight / TOTAL_DRIPS_WEIGHTS`
     /// share of the funds collected by the user.
+    /// @return collected The collected amount
+    /// @return dripped The amount dripped to the user's receivers
     function setDripsReceivers(
         DripsReceiver[] calldata currReceivers,
         DripsReceiver[] calldata newReceivers
-    ) public {
-        _setDripsReceiversInternal(msg.sender, currReceivers, newReceivers);
+    ) public returns (uint128 collected, uint128 dripped) {
+        return _setDripsReceiversInternal(msg.sender, currReceivers, newReceivers);
     }
 
     function _transfer(address userAddr, int128 amt) internal override {

--- a/src/EthPool.sol
+++ b/src/EthPool.sol
@@ -22,9 +22,6 @@ contract EthPool is Pool {
     /// Sends the withdrawn funds to the sender of the message.
     /// @param withdraw The amount to be withdrawn, must not be higher than available funds.
     /// Can be `WITHDRAW_ALL` to withdraw everything.
-    /// @param dripsFraction The fraction of received funds to be dripped.
-    /// Must be a value from 0 to `MAX_DRIPS_FRACTION` inclusively,
-    /// where 0 means no dripping and `MAX_DRIPS_FRACTION` dripping everything.
     /// @param currReceivers The list of the user's receivers which is currently in use.
     /// If this function is called for the first time for the user, should be an empty array.
     /// @param newReceivers The new list of the user's receivers.
@@ -33,7 +30,6 @@ contract EthPool is Pool {
     /// Equal to `withdrawAmt` unless `WITHDRAW_ALL` is used.
     function updateSender(
         uint128 withdraw,
-        uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
     ) public payable returns (uint128 withdrawn) {
@@ -42,7 +38,6 @@ contract EthPool is Pool {
                 msg.sender,
                 uint128(msg.value),
                 withdraw,
-                dripsFraction,
                 currReceivers,
                 newReceivers
             );

--- a/src/EthPool.sol
+++ b/src/EthPool.sol
@@ -28,24 +28,15 @@ contract EthPool is Pool {
     /// @param currReceivers The list of the user's receivers which is currently in use.
     /// If this function is called for the first time for the user, should be an empty array.
     /// @param newReceivers The new list of the user's receivers.
+    /// Must be sorted by the receivers' addresses, deduplicated and without 0 amtPerSecs.
     /// @return withdrawn The actually withdrawn amount.
     /// Equal to `withdrawAmt` unless `WITHDRAW_ALL` is used.
-    /// @return collected The collected amount
-    /// @return dripped The amount dripped to the user's receivers
     function updateSender(
         uint128 withdraw,
         uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
-    )
-        public
-        payable
-        returns (
-            uint128 withdrawn,
-            uint128 collected,
-            uint128 dripped
-        )
-    {
+    ) public payable returns (uint128 withdrawn) {
         return
             _updateSenderInternal(
                 msg.sender,

--- a/src/EthPool.sol
+++ b/src/EthPool.sol
@@ -78,18 +78,21 @@ contract EthPool is Pool {
         _giveFromSubSenderInternal(msg.sender, subSenderId, receiver, uint128(msg.value));
     }
 
-    /// @notice Sets a new list of drips receivers of the sender of the message.
+    /// @notice Collects received funds and sets a new list of drips receivers
+    /// of the sender of the message.
     /// @param currReceivers The list of the user's drips receivers which is currently in use.
     /// If this function is called for the first time for the user, should be an empty array.
     /// @param newReceivers The new list of the user's drips receivers.
     /// Must be sorted by the drips receivers' addresses, deduplicated and without 0 weights.
     /// Each drips receiver will be getting `weight / TOTAL_DRIPS_WEIGHTS`
     /// share of the funds collected by the user.
+    /// @return collected The collected amount
+    /// @return dripped The amount dripped to the user's receivers
     function setDripsReceivers(
         DripsReceiver[] calldata currReceivers,
         DripsReceiver[] calldata newReceivers
-    ) public {
-        _setDripsReceiversInternal(msg.sender, currReceivers, newReceivers);
+    ) public returns (uint128 collected, uint128 dripped) {
+        return _setDripsReceiversInternal(msg.sender, currReceivers, newReceivers);
     }
 
     function _transfer(address userAddr, int128 amt) internal override {

--- a/src/test/Pool.t.sol
+++ b/src/test/Pool.t.sol
@@ -543,47 +543,6 @@ abstract contract PoolTest is PoolUserUtils {
         collect(receiver3, 2);
     }
 
-    function testUpdateSenderCollects() public {
-        updateSender(sender1, 0, 10, 0, receivers(sender2, 10));
-        warpToCycleEnd();
-        uint256 balanceOld = sender2.balance();
-        (uint128 withdrawn, uint128 collected, uint128 dripped) = sender2.updateSender(
-            0,
-            0,
-            0,
-            receivers(),
-            receivers()
-        );
-        assertEq(withdrawn, 0, "Invalid withdrawn");
-        assertEq(collected, 10, "Invalid collected");
-        assertEq(dripped, 0, "Invalid dripped");
-        assertBalance(sender2, balanceOld + 10);
-    }
-
-    function testUpdateSenderDrips() public {
-        uint32 dripsFractionMax = sender.getDripsFractionMax();
-        // Sender2 drips to receiver1
-        updateSender(sender2, 0, 0, dripsFractionMax, receivers(receiver1, 1));
-        updateSender(sender1, 0, 10, 0, receivers(sender2, 10));
-        warpToCycleEnd();
-        uint256 balanceOld = sender2.balance();
-        // New sender2 configuration, stops dripping to receiver1
-        (uint128 withdrawn, uint128 collected, uint128 dripped) = sender2.updateSender(
-            0,
-            0,
-            0,
-            receivers(receiver1, 1),
-            receivers(receiver2, 1)
-        );
-        assertEq(withdrawn, 0, "Invalid withdrawn");
-        assertEq(collected, 0, "Invalid collected");
-        assertEq(dripped, 10, "Invalid dripped");
-        assertBalance(sender2, balanceOld);
-        // Dripped according to the old sender2 configuration
-        collect(receiver1, 10);
-        assertCollectable(receiver2, 0);
-    }
-
     function testFlushSomeCycles() public {
         // Enough for 3 cycles
         uint128 amt = pool.cycleSecs() * 3;

--- a/src/test/Pool.t.sol
+++ b/src/test/Pool.t.sol
@@ -47,7 +47,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsSendingToASingleReceiver() public {
-        updateSender(sender, 0, 100, 0, receivers(receiver, 1));
+        updateSender(sender, 0, 100, receivers(receiver, 1));
         warpBy(15);
         // Sender had 15 seconds paying 1 per second
         changeBalance(sender, 85, 0);
@@ -61,7 +61,7 @@ abstract contract PoolTest is PoolUserUtils {
     {
         uint128 time = (cycles / 10) * pool.cycleSecs() + (timeInCycle % pool.cycleSecs());
         uint128 balance = 25 * pool.cycleSecs() + 256;
-        updateSender(sender, 0, balance, 0, receivers(receiver, 1));
+        updateSender(sender, 0, balance, receivers(receiver, 1));
         warpBy(time);
         // Sender had `time` seconds paying 1 per second
         changeBalance(sender, balance - time, 0);
@@ -71,7 +71,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsSendingToMultipleReceivers() public {
-        updateSender(sender, 0, 6, 0, receivers(receiver1, 1, receiver2, 2));
+        updateSender(sender, 0, 6, receivers(receiver1, 1, receiver2, 2));
         warpToCycleEnd();
         // Sender had 2 seconds paying 1 per second
         collect(receiver1, 2);
@@ -80,7 +80,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testSendsSomeFundsFromASingleSenderToTwoReceivers() public {
-        updateSender(sender, 0, 100, 0, receivers(receiver1, 1, receiver2, 1));
+        updateSender(sender, 0, 100, receivers(receiver1, 1, receiver2, 1));
         warpBy(14);
         // Sender had 14 seconds paying 2 per second
         changeBalance(sender, 72, 0);
@@ -92,9 +92,9 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testSendsSomeFundsFromATwoSendersToASingleReceiver() public {
-        updateSender(sender1, 0, 100, 0, receivers(receiver, 1));
+        updateSender(sender1, 0, 100, receivers(receiver, 1));
         warpBy(2);
-        updateSender(sender2, 0, 100, 0, receivers(receiver, 2));
+        updateSender(sender2, 0, 100, receivers(receiver, 2));
         warpBy(15);
         // Sender1 had 17 seconds paying 1 per second
         changeBalance(sender1, 83, 0);
@@ -110,7 +110,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsCollectingFundsWhileTheyAreBeingSent() public {
-        updateSender(sender, 0, pool.cycleSecs() + 10, 0, receivers(receiver, 1));
+        updateSender(sender, 0, pool.cycleSecs() + 10, receivers(receiver, 1));
         warpToCycleEnd();
         // Receiver had cycleSecs seconds paying 1 per second
         collect(receiver, pool.cycleSecs());
@@ -132,7 +132,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testSendsFundsUntilTheyRunOut() public {
-        updateSender(sender, 0, 100, 0, receivers(receiver, 9));
+        updateSender(sender, 0, 100, receivers(receiver, 9));
         warpBy(10);
         // Sender had 10 seconds paying 9 per second, funds are about to run out
         assertWithdrawable(sender, 10);
@@ -159,7 +159,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsToppingUpWhileSending() public {
-        updateSender(sender, 0, 100, 0, receivers(receiver, 10));
+        updateSender(sender, 0, 100, receivers(receiver, 10));
         warpBy(6);
         // Sender had 6 seconds paying 10 per second
         changeBalance(sender, 40, 60);
@@ -172,7 +172,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsToppingUpAfterFundsRunOut() public {
-        updateSender(sender, 0, 100, 0, receivers(receiver, 10));
+        updateSender(sender, 0, 100, receivers(receiver, 10));
         warpBy(10);
         // Sender had 10 seconds paying 10 per second
         assertWithdrawable(sender, 0);
@@ -190,7 +190,7 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testAllowsSendingWhichShouldEndAfterMaxTimestamp() public {
         uint128 balance = type(uint64).max + uint128(6);
-        updateSender(sender, 0, balance, 0, receivers(receiver, 1));
+        updateSender(sender, 0, balance, receivers(receiver, 1));
         warpBy(10);
         // Sender had 10 seconds paying 1 per second
         changeBalance(sender, balance - 10, 0);
@@ -200,21 +200,21 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsSenderUpdateWithTopUpAndWithdrawal() public {
-        sender.updateSender(10, 3, 0, receivers(), receivers());
+        sender.updateSender(10, 3, receivers(), receivers());
         assertWithdrawable(sender, 7);
     }
 
     function testAllowsNoSenderUpdate() public {
-        updateSender(sender, 0, 6, 0, receivers(receiver, 3));
+        updateSender(sender, 0, 6, receivers(receiver, 3));
         warpBy(1);
         // Sender had 1 second paying 3 per second
-        updateSender(sender, 3, 3, 0, receivers(receiver, 1));
+        updateSender(sender, 3, 3, receivers(receiver, 1));
         warpToCycleEnd();
         collect(receiver, 6);
     }
 
     function testAllowsChangingReceiversWhileSending() public {
-        updateSender(sender, 0, 100, 0, receivers(receiver1, 6, receiver2, 6));
+        updateSender(sender, 0, 100, receivers(receiver1, 6, receiver2, 6));
         warpBy(3);
         setReceivers(sender, receivers(receiver1, 4, receiver2, 8));
         warpBy(4);
@@ -228,7 +228,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsRemovingReceiversWhileSending() public {
-        updateSender(sender, 0, 100, 0, receivers(receiver1, 5, receiver2, 5));
+        updateSender(sender, 0, 100, receivers(receiver1, 5, receiver2, 5));
         warpBy(3);
         setReceivers(sender, receivers(receiver2, 10));
         warpBy(4);
@@ -287,8 +287,8 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testUpdateSenderRevertsIfInvalidCurrReceivers() public {
-        updateSender(sender, 0, 0, 0, receivers(receiver, 1));
-        try sender.updateSender(0, 0, 0, receivers(receiver, 2), receivers()) {
+        updateSender(sender, 0, 0, receivers(receiver, 1));
+        try sender.updateSender(0, 0, receivers(receiver, 2), receivers()) {
             assertTrue(false, "Sender update hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, "Invalid current receivers", "Invalid sender update revert reason");
@@ -296,7 +296,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsAnAddressToBeASenderAndAReceiverIndependently() public {
-        updateSender(sender, 0, 10, 0, receivers(sender, 10));
+        updateSender(sender, 0, 10, receivers(sender, 10));
         warpBy(1);
         // Sender had 1 second paying 10 per second
         assertWithdrawable(sender, 0);
@@ -306,18 +306,12 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAllowsWithdrawalOfAllFunds() public {
-        updateSender(sender, 0, 10, 0, receivers(receiver, 1));
+        updateSender(sender, 0, 10, receivers(receiver, 1));
         warpBy(4);
         // Sender had 4 second paying 1 per second
         assertWithdrawable(sender, 6);
         uint256 expectedBalance = sender.balance() + 6;
-        sender.updateSender(
-            0,
-            pool.WITHDRAW_ALL(),
-            0,
-            receivers(receiver, 1),
-            receivers(receiver, 1)
-        );
+        sender.updateSender(0, pool.WITHDRAW_ALL(), receivers(receiver, 1), receivers(receiver, 1));
         assertWithdrawable(sender, 0);
         assertBalance(sender, expectedBalance);
         warpToCycleEnd();
@@ -326,7 +320,7 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testWithdrawableRevertsIfInvalidCurrReceivers() public {
-        updateSender(sender, 0, 0, 0, receivers(receiver, 1));
+        updateSender(sender, 0, 0, receivers(receiver, 1));
         try sender.withdrawable(receivers(receiver, 2)) {
             assertTrue(false, "Withdrawable hasn't reverted");
         } catch Error(string memory reason) {
@@ -344,14 +338,14 @@ abstract contract PoolTest is PoolUserUtils {
     }
 
     function testAnybodyCanCallCollect() public {
-        updateSender(sender1, 0, 10, 0, receivers(receiver, 10));
+        updateSender(sender1, 0, 10, receivers(receiver, 10));
         warpToCycleEnd();
         // Receiver had 1 second paying 10 per second
         collect(sender2, receiver, 10);
     }
 
     function testSenderAndSubSenderAreIndependent() public {
-        updateSender(sender, 0, 5, 0, receivers(receiver1, 1));
+        updateSender(sender, 0, 5, receivers(receiver1, 1));
         warpBy(3);
         updateSubSender(sender, SUB_SENDER_1, 0, 8, receivers(receiver1, 2, receiver2, 1));
         warpBy(1);
@@ -462,19 +456,9 @@ abstract contract PoolTest is PoolUserUtils {
         }
     }
 
-    function testDripsFractionIsLimited() public {
-        uint32 dripsFractionMax = sender.getDripsFractionMax();
-        updateSender(sender, 0, 0, dripsFractionMax, receivers());
-        try sender.updateSender(0, 0, dripsFractionMax + 1, receivers(), receivers()) {
-            assertTrue(false, "Update senders hasn't reverted");
-        } catch Error(string memory reason) {
-            assertEq(reason, "Drip fraction too high", "Invalid update sender revert reason");
-        }
-    }
-
     function testCollectDrips() public {
         uint32 totalWeight = pool.TOTAL_DRIPS_WEIGHTS();
-        updateSender(sender, 0, 10, 0, receivers(receiver1, 10));
+        updateSender(sender, 0, 10, receivers(receiver1, 10));
         setDripsReceivers(receiver1, dripsReceivers(receiver2, totalWeight));
         warpToCycleEnd();
         assertCollectable(receiver2, 0);
@@ -486,7 +470,7 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testCollectDripsFundsFromDrips() public {
         uint32 totalWeight = pool.TOTAL_DRIPS_WEIGHTS();
-        updateSender(sender, 0, 10, 0, receivers(receiver1, 10));
+        updateSender(sender, 0, 10, receivers(receiver1, 10));
         setDripsReceivers(receiver1, dripsReceivers(receiver2, totalWeight));
         setDripsReceivers(receiver2, dripsReceivers(receiver3, totalWeight));
         warpToCycleEnd();
@@ -502,7 +486,7 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testCollectMixesStreamsAndDrips() public {
         uint32 totalWeight = pool.TOTAL_DRIPS_WEIGHTS();
-        updateSender(sender, 0, 10, 0, receivers(receiver1, 5, receiver2, 5));
+        updateSender(sender, 0, 10, receivers(receiver1, 5, receiver2, 5));
         setDripsReceivers(receiver1, dripsReceivers(receiver2, totalWeight));
         warpToCycleEnd();
         // Receiver2 had 1 second paying 5 per second
@@ -515,7 +499,7 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testCollectSplitsFundsBetweenReceiverAndDrips() public {
         uint32 totalWeight = pool.TOTAL_DRIPS_WEIGHTS();
-        updateSender(sender, 0, 10, 0, receivers(receiver1, 10));
+        updateSender(sender, 0, 10, receivers(receiver1, 10));
         setDripsReceivers(
             receiver1,
             dripsReceivers(receiver2, totalWeight / 4, receiver3, totalWeight / 2)
@@ -533,7 +517,7 @@ abstract contract PoolTest is PoolUserUtils {
 
     function testCanDripAllWhenCollectedDoesntSplitEvenly() public {
         uint32 totalWeight = pool.TOTAL_DRIPS_WEIGHTS();
-        updateSender(sender, 0, 3, 0, receivers(receiver1, 3));
+        updateSender(sender, 0, 3, receivers(receiver1, 3));
         setDripsReceivers(
             receiver1,
             dripsReceivers(receiver2, totalWeight / 2, receiver3, totalWeight / 2)
@@ -551,7 +535,7 @@ abstract contract PoolTest is PoolUserUtils {
         // Enough for 3 cycles
         uint128 amt = pool.cycleSecs() * 3;
         warpToCycleEnd();
-        updateSender(sender, 0, amt, 0, receivers(receiver, 1));
+        updateSender(sender, 0, amt, receivers(receiver, 1));
         warpToCycleEnd();
         warpToCycleEnd();
         warpToCycleEnd();
@@ -563,7 +547,7 @@ abstract contract PoolTest is PoolUserUtils {
         // Enough for 3 cycles
         uint128 amt = pool.cycleSecs() * 3;
         warpToCycleEnd();
-        updateSender(sender, 0, amt, 0, receivers(receiver, 1));
+        updateSender(sender, 0, amt, receivers(receiver, 1));
         warpToCycleEnd();
         warpToCycleEnd();
         warpToCycleEnd();

--- a/src/test/Pool.t.sol
+++ b/src/test/Pool.t.sol
@@ -443,7 +443,7 @@ abstract contract PoolTest is PoolUserUtils {
         );
     }
 
-    function testUpdateSenderRevertsIfInvalidCurrDripsReceivers() public {
+    function testSetDripsReceiversRevertsIfInvalidCurrDripsReceivers() public {
         setDripsReceivers(sender, dripsReceivers(receiver, 1));
         try sender.setDripsReceivers(dripsReceivers(receiver, 2), dripsReceivers()) {
             assertTrue(false, "Sender update hasn't reverted");
@@ -454,6 +454,21 @@ abstract contract PoolTest is PoolUserUtils {
                 "Invalid sender update revert reason"
             );
         }
+    }
+
+    function testSetDripsReceiversCollects() public {
+        updateSender(sender, 0, 10, receivers(receiver, 10));
+        warpToCycleEnd();
+        setDripsReceivers(receiver, dripsReceivers(), 10, 0);
+    }
+
+    function testSetDripsReceiversDrips() public {
+        uint32 totalWeight = pool.TOTAL_DRIPS_WEIGHTS();
+        updateSender(sender, 0, 10, receivers(receiver1, 10));
+        setDripsReceivers(receiver1, dripsReceivers(receiver2, totalWeight));
+        warpToCycleEnd();
+        setDripsReceivers(receiver1, dripsReceivers(), 0, 10);
+        collect(receiver2, 10);
     }
 
     function testCollectDrips() public {

--- a/src/test/User.t.sol
+++ b/src/test/User.t.sol
@@ -36,7 +36,7 @@ abstract contract PoolUser {
     function setDripsReceivers(
         DripsReceiver[] calldata currReceivers,
         DripsReceiver[] calldata newReceivers
-    ) public virtual;
+    ) public virtual returns (uint128 collected, uint128 dripped);
 
     function collect(address receiverAddr, DripsReceiver[] calldata currReceivers)
         public
@@ -151,8 +151,8 @@ contract ERC20PoolUser is PoolUser {
     function setDripsReceivers(
         DripsReceiver[] calldata currReceivers,
         DripsReceiver[] calldata newReceivers
-    ) public override {
-        pool.setDripsReceivers(currReceivers, newReceivers);
+    ) public override returns (uint128 collected, uint128 dripped) {
+        return pool.setDripsReceivers(currReceivers, newReceivers);
     }
 }
 
@@ -214,7 +214,7 @@ contract EthPoolUser is PoolUser {
     function setDripsReceivers(
         DripsReceiver[] calldata currReceivers,
         DripsReceiver[] calldata newReceivers
-    ) public override {
-        pool.setDripsReceivers(currReceivers, newReceivers);
+    ) public override returns (uint128 collected, uint128 dripped) {
+        return pool.setDripsReceivers(currReceivers, newReceivers);
     }
 }

--- a/src/test/User.t.sol
+++ b/src/test/User.t.sol
@@ -43,14 +43,14 @@ abstract contract PoolUser {
         DripsReceiver[] calldata newReceivers
     ) public virtual;
 
-    function collect(address receiverAddr, Receiver[] calldata currReceivers)
+    function collect(address receiverAddr, DripsReceiver[] calldata currReceivers)
         public
         returns (uint128 collected, uint128 dripped)
     {
         return getPool().collect(receiverAddr, currReceivers);
     }
 
-    function collectable(Receiver[] calldata currReceivers)
+    function collectable(DripsReceiver[] calldata currReceivers)
         public
         view
         returns (uint128 collected, uint128 dripped)

--- a/src/test/User.t.sol
+++ b/src/test/User.t.sol
@@ -10,14 +10,9 @@ abstract contract PoolUser {
 
     function balance() public view virtual returns (uint256);
 
-    function getDripsFractionMax() public view returns (uint32) {
-        return getPool().MAX_DRIPS_FRACTION();
-    }
-
     function updateSender(
         uint128 toppedUp,
         uint128 withdraw,
-        uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
     ) public virtual returns (uint128 withdrawn);
@@ -78,10 +73,6 @@ abstract contract PoolUser {
         return getPool().withdrawableSubSender(address(this), subSenderId, currReceivers);
     }
 
-    function getDripsFraction() public view returns (uint32) {
-        return getPool().getDripsFraction(address(this));
-    }
-
     function hashReceivers(Receiver[] calldata receivers) public view returns (bytes32) {
         return getPool().hashReceivers(receivers);
     }
@@ -125,12 +116,11 @@ contract ERC20PoolUser is PoolUser {
     function updateSender(
         uint128 toppedUp,
         uint128 withdraw,
-        uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
     ) public override returns (uint128 withdrawn) {
         pool.erc20().approve(address(pool), toppedUp);
-        return pool.updateSender(toppedUp, withdraw, dripsFraction, currReceivers, newReceivers);
+        return pool.updateSender(toppedUp, withdraw, currReceivers, newReceivers);
     }
 
     function updateSubSender(
@@ -187,17 +177,10 @@ contract EthPoolUser is PoolUser {
     function updateSender(
         uint128 toppedUp,
         uint128 withdraw,
-        uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
     ) public override returns (uint128 withdrawn) {
-        return
-            pool.updateSender{value: toppedUp}(
-                withdraw,
-                dripsFraction,
-                currReceivers,
-                newReceivers
-            );
+        return pool.updateSender{value: toppedUp}(withdraw, currReceivers, newReceivers);
     }
 
     function updateSubSender(

--- a/src/test/User.t.sol
+++ b/src/test/User.t.sol
@@ -20,14 +20,7 @@ abstract contract PoolUser {
         uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
-    )
-        public
-        virtual
-        returns (
-            uint128 withdrawn,
-            uint128 collected,
-            uint128 dripped
-        );
+    ) public virtual returns (uint128 withdrawn);
 
     function updateSubSender(
         uint256 subSenderId,
@@ -135,15 +128,7 @@ contract ERC20PoolUser is PoolUser {
         uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
-    )
-        public
-        override
-        returns (
-            uint128 withdrawn,
-            uint128 collected,
-            uint128 dripped
-        )
-    {
+    ) public override returns (uint128 withdrawn) {
         pool.erc20().approve(address(pool), toppedUp);
         return pool.updateSender(toppedUp, withdraw, dripsFraction, currReceivers, newReceivers);
     }
@@ -205,15 +190,7 @@ contract EthPoolUser is PoolUser {
         uint32 dripsFraction,
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
-    )
-        public
-        override
-        returns (
-            uint128 withdrawn,
-            uint128 collected,
-            uint128 dripped
-        )
-    {
+    ) public override returns (uint128 withdrawn) {
         return
             pool.updateSender{value: toppedUp}(
                 withdraw,

--- a/src/test/UserUtils.t.sol
+++ b/src/test/UserUtils.t.sol
@@ -83,7 +83,6 @@ abstract contract PoolUserUtils is DSTest {
         PoolUser user,
         uint128 balanceFrom,
         uint128 balanceTo,
-        uint32 dripsFraction,
         Receiver[] memory newReceivers
     ) internal {
         assertWithdrawable(user, balanceFrom);
@@ -93,23 +92,12 @@ abstract contract PoolUserUtils is DSTest {
         Receiver[] memory curr = getCurrReceivers(user);
         assertReceivers(user, curr);
 
-        uint128 withdrawn = user.updateSender(
-            toppedUp,
-            withdraw,
-            dripsFraction,
-            curr,
-            newReceivers
-        );
+        uint128 withdrawn = user.updateSender(toppedUp, withdraw, curr, newReceivers);
 
         setCurrReceivers(user, newReceivers);
         assertEq(withdrawn, withdraw, "Expected amount not withdrawn");
         assertWithdrawable(user, balanceTo);
         assertBalance(user, expectedBalance);
-        assertEq(
-            user.getDripsFraction(),
-            dripsFraction,
-            "Invalid dripsFraction after updateSender"
-        );
         assertReceivers(user, newReceivers);
     }
 
@@ -129,12 +117,12 @@ abstract contract PoolUserUtils is DSTest {
         uint128 balanceFrom,
         uint128 balanceTo
     ) internal {
-        updateSender(user, balanceFrom, balanceTo, user.getDripsFraction(), getCurrReceivers(user));
+        updateSender(user, balanceFrom, balanceTo, getCurrReceivers(user));
     }
 
     function setReceivers(PoolUser user, Receiver[] memory newReceivers) internal {
         uint128 withdrawable = user.withdrawable(getCurrReceivers(user));
-        updateSender(user, withdrawable, withdrawable, user.getDripsFraction(), newReceivers);
+        updateSender(user, withdrawable, withdrawable, newReceivers);
     }
 
     function assertSetReceiversReverts(
@@ -142,7 +130,7 @@ abstract contract PoolUserUtils is DSTest {
         Receiver[] memory newReceivers,
         string memory expectedReason
     ) internal {
-        try user.updateSender(0, 0, user.getDripsFraction(), getCurrReceivers(user), newReceivers) {
+        try user.updateSender(0, 0, getCurrReceivers(user), newReceivers) {
             assertTrue(false, "Sender receivers update hasn't reverted");
         } catch Error(string memory reason) {
             assertEq(reason, expectedReason, "Invalid sender receivers update revert reason");

--- a/src/test/UserUtils.t.sol
+++ b/src/test/UserUtils.t.sol
@@ -228,13 +228,28 @@ abstract contract PoolUserUtils is DSTest {
     }
 
     function setDripsReceivers(PoolUser user, DripsReceiver[] memory newReceivers) internal {
+        setDripsReceivers(user, newReceivers, 0, 0);
+    }
+
+    function setDripsReceivers(
+        PoolUser user,
+        DripsReceiver[] memory newReceivers,
+        uint128 expectedCollected,
+        uint128 expectedDripped
+    ) internal {
         DripsReceiver[] memory curr = getCurrDripsReceivers(user);
         assertDripsReceivers(user, curr);
+        assertCollectable(user, expectedCollected, expectedDripped);
+        uint256 expectedBalance = user.balance() + expectedCollected;
 
-        user.setDripsReceivers(curr, newReceivers);
+        (uint128 collected, uint128 dripped) = user.setDripsReceivers(curr, newReceivers);
 
         setCurrDripsReceivers(user, newReceivers);
         assertDripsReceivers(user, newReceivers);
+        assertEq(collected, expectedCollected, "Invalid collected amount");
+        assertEq(dripped, expectedDripped, "Invalid dripped amount");
+        assertCollectable(user, 0, 0);
+        assertBalance(user, expectedBalance);
     }
 
     function assertSetDripsReceiversReverts(

--- a/src/test/UserUtils.t.sol
+++ b/src/test/UserUtils.t.sol
@@ -302,7 +302,7 @@ abstract contract PoolUserUtils is DSTest {
 
         (uint128 collectedAmt, uint128 drippedAmt) = user.collect(
             address(collected),
-            getCurrReceivers(user)
+            getCurrDripsReceivers(user)
         );
 
         assertEq(collectedAmt, expectedCollected, "Invalid collected amount");
@@ -320,7 +320,9 @@ abstract contract PoolUserUtils is DSTest {
         uint128 expectedCollected,
         uint128 expectedDripped
     ) internal {
-        (uint128 actualCollected, uint128 actualDripped) = user.collectable(getCurrReceivers(user));
+        (uint128 actualCollected, uint128 actualDripped) = user.collectable(
+            getCurrDripsReceivers(user)
+        );
         assertEq(actualCollected, expectedCollected, "Invalid collectable");
         assertEq(actualDripped, expectedDripped, "Invalid drippable");
     }

--- a/src/test/UserUtils.t.sol
+++ b/src/test/UserUtils.t.sol
@@ -93,7 +93,7 @@ abstract contract PoolUserUtils is DSTest {
         Receiver[] memory curr = getCurrReceivers(user);
         assertReceivers(user, curr);
 
-        (uint128 withdrawn, uint128 collected, uint128 dripped) = user.updateSender(
+        uint128 withdrawn = user.updateSender(
             toppedUp,
             withdraw,
             dripsFraction,
@@ -103,8 +103,6 @@ abstract contract PoolUserUtils is DSTest {
 
         setCurrReceivers(user, newReceivers);
         assertEq(withdrawn, withdraw, "Expected amount not withdrawn");
-        assertEq(collected, 0, "Expected non-withdrawing sender update");
-        assertEq(dripped, 0, "Expected non-dripping sender update");
         assertWithdrawable(user, balanceTo);
         assertBalance(user, expectedBalance);
         assertEq(


### PR DESCRIPTION
Depends on https://github.com/radicle-dev/radicle-streaming/pull/53. Switches drips from using the senders' receivers lists to drips receivers lists. It's probably the best to review commit by commit, each of them is self-contained.