### PR TITLE
Use SenderId in internal functions

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -40,7 +40,8 @@ contract ERC20Pool is Pool {
         Receiver[] calldata currReceivers,
         Receiver[] calldata newReceivers
     ) public returns (uint128 withdrawn) {
-        return _updateSenderInternal(msg.sender, topUpAmt, withdraw, currReceivers, newReceivers);
+        return
+            _updateSender(_senderId(msg.sender), topUpAmt, withdraw, currReceivers, newReceivers);
     }
 
     /// @notice Updates all the parameters of a sub-sender of the sender of the message.
@@ -54,9 +55,8 @@ contract ERC20Pool is Pool {
         Receiver[] calldata newReceivers
     ) public payable returns (uint128 withdrawn) {
         return
-            _updateSubSenderInternal(
-                msg.sender,
-                subSenderId,
+            _updateSender(
+                _senderId(msg.sender, subSenderId),
                 topUpAmt,
                 withdraw,
                 currReceivers,
@@ -69,7 +69,7 @@ contract ERC20Pool is Pool {
     /// @param receiver The receiver
     /// @param amt The sent amount
     function give(address receiver, uint128 amt) public {
-        _giveInternal(msg.sender, receiver, amt);
+        _give(_senderId(msg.sender), receiver, amt);
     }
 
     /// @notice Gives funds from the sub-sender of the sender of the message to the receiver.
@@ -82,7 +82,7 @@ contract ERC20Pool is Pool {
         address receiver,
         uint128 amt
     ) public {
-        _giveFromSubSenderInternal(msg.sender, subSenderId, receiver, amt);
+        _give(_senderId(msg.sender, subSenderId), receiver, amt);
     }
 
     /// @notice Collects received funds and sets a new list of drips receivers
@@ -99,7 +99,7 @@ contract ERC20Pool is Pool {
         DripsReceiver[] calldata currReceivers,
         DripsReceiver[] calldata newReceivers
     ) public returns (uint128 collected, uint128 dripped) {
-        return _setDripsReceiversInternal(msg.sender, currReceivers, newReceivers);
+        return _setDripsReceivers(msg.sender, currReceivers, newReceivers);
     }
 
     function _transfer(address userAddr, int128 amt) internal override {

--- a/src/EthPool.sol
+++ b/src/EthPool.sol
@@ -34,8 +34,8 @@ contract EthPool is Pool {
         Receiver[] calldata newReceivers
     ) public payable returns (uint128 withdrawn) {
         return
-            _updateSenderInternal(
-                msg.sender,
+            _updateSender(
+                _senderId(msg.sender),
                 uint128(msg.value),
                 withdraw,
                 currReceivers,
@@ -53,9 +53,8 @@ contract EthPool is Pool {
         Receiver[] calldata newReceivers
     ) public payable returns (uint128 withdrawn) {
         return
-            _updateSubSenderInternal(
-                msg.sender,
-                subSenderId,
+            _updateSender(
+                _senderId(msg.sender, subSenderId),
                 uint128(msg.value),
                 withdraw,
                 currReceivers,
@@ -67,7 +66,7 @@ contract EthPool is Pool {
     /// The receiver can collect them immediately.
     /// @param receiver The receiver
     function give(address receiver) public payable {
-        _giveInternal(msg.sender, receiver, uint128(msg.value));
+        _give(_senderId(msg.sender), receiver, uint128(msg.value));
     }
 
     /// @notice Gives funds from the sub-sender of the sender of the message to the receiver.
@@ -75,7 +74,7 @@ contract EthPool is Pool {
     /// @param subSenderId The id of the giver's sub-sender
     /// @param receiver The receiver
     function giveFromSubSender(uint256 subSenderId, address receiver) public payable {
-        _giveFromSubSenderInternal(msg.sender, subSenderId, receiver, uint128(msg.value));
+        _give(_senderId(msg.sender, subSenderId), receiver, uint128(msg.value));
     }
 
     /// @notice Collects received funds and sets a new list of drips receivers
@@ -92,7 +91,7 @@ contract EthPool is Pool {
         DripsReceiver[] calldata currReceivers,
         DripsReceiver[] calldata newReceivers
     ) public returns (uint128 collected, uint128 dripped) {
-        return _setDripsReceiversInternal(msg.sender, currReceivers, newReceivers);
+        return _setDripsReceivers(msg.sender, currReceivers, newReceivers);
     }
 
     function _transfer(address userAddr, int128 amt) internal override {


### PR DESCRIPTION
This allows removing some duplicate logic and clean up functions naming. It's a purely refactoring PR.