### PR TITLE
Drop withdrawable

### DIFF
--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -583,67 +583,6 @@ abstract contract Pool {
         return endTime > MAX_TIMESTAMP ? MAX_TIMESTAMP : uint64(endTime);
     }
 
-    /// @notice Returns amount of unsent funds available for withdrawal for the sender
-    /// @param senderAddr The address of the sender
-    /// @param lastUpdate The timestamp of the last update of the sender.
-    /// If this is the first update of the sender, pass zero.
-    /// @param lastBalance The balance after the last update of the sender.
-    /// If this is the first update of the sender, pass zero.
-    /// @param currReceivers The list of receivers set in the last update of the sender.
-    /// @return withdrawableAmt The withdrawable amount
-    function withdrawable(
-        address senderAddr,
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        Receiver[] calldata currReceivers
-    ) public view returns (uint128 withdrawableAmt) {
-        SenderId memory senderId = _senderId(senderAddr);
-        return _withdrawable(senderId, lastUpdate, lastBalance, currReceivers);
-    }
-
-    /// @notice Returns amount of unsent funds available for withdrawal for the sub-sender
-    /// @param senderAddr The address of the sender
-    /// @param subSenderId The id of the sender's sub-sender
-    /// @param lastUpdate The timestamp of the last update of the sender.
-    /// If this is the first update of the sender, pass zero.
-    /// @param lastBalance The balance after the last update of the sender.
-    /// If this is the first update of the sender, pass zero.
-    /// @param currReceivers The list of receivers set in the last update of the sender.
-    /// @return withdrawableAmt The withdrawable amount
-    function withdrawableSubSender(
-        address senderAddr,
-        uint256 subSenderId,
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        Receiver[] calldata currReceivers
-    ) public view returns (uint128 withdrawableAmt) {
-        SenderId memory senderId = _senderId(senderAddr, subSenderId);
-        return _withdrawable(senderId, lastUpdate, lastBalance, currReceivers);
-    }
-
-    /// @notice Returns amount of unsent funds available for withdrawal for the sender.
-    /// @param senderId The id of the sender
-    /// @param lastUpdate The timestamp of the last update of the sender.
-    /// If this is the first update of the sender, pass zero.
-    /// @param lastBalance The balance after the last update of the sender.
-    /// If this is the first update of the sender, pass zero.
-    /// @param currReceivers The list of receivers set in the last update of the sender.
-    /// @return withdrawableAmt The withdrawable amount
-    function _withdrawable(
-        SenderId memory senderId,
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        Receiver[] calldata currReceivers
-    ) internal view returns (uint128 withdrawableAmt) {
-        _assertSenderState(senderId, lastUpdate, lastBalance, currReceivers);
-        uint128 amtPerSec = _totalAmtPerSec(currReceivers);
-        uint192 alreadySent = uint192(_currTimestamp() - lastUpdate) * amtPerSec;
-        if (alreadySent > lastBalance) {
-            return lastBalance % amtPerSec;
-        }
-        return lastBalance - uint128(alreadySent);
-    }
-
     /// @notice Asserts that the sender state is the currently used one.
     /// @param senderId The id of the sender
     /// @param lastUpdate The timestamp of the last update of the sender.

--- a/src/test/User.t.sol
+++ b/src/test/User.t.sol
@@ -63,30 +63,6 @@ abstract contract PoolUser {
         return getPool().flushCycles(address(this), maxCycles);
     }
 
-    function withdrawable(
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        Receiver[] calldata currReceivers
-    ) public view returns (uint128) {
-        return getPool().withdrawable(address(this), lastUpdate, lastBalance, currReceivers);
-    }
-
-    function withdrawableSubSender(
-        uint256 subSenderId,
-        uint64 lastUpdate,
-        uint128 lastBalance,
-        Receiver[] calldata currReceivers
-    ) public view returns (uint128) {
-        return
-            getPool().withdrawableSubSender(
-                address(this),
-                subSenderId,
-                lastUpdate,
-                lastBalance,
-                currReceivers
-            );
-    }
-
     function hashSenderState(
         uint64 lastUpdate,
         uint128 lastBalance,


### PR DESCRIPTION
~Depends on https://github.com/radicle-dev/radicle-streaming/pull/59. Completes naming transition from `topUp` and `withdraw` to `sender balance`.~

~Now that I'm thinking about it, **maybe we should drop `withdrawable/senderBalance` entirely?** Without any on-chain sender state left it's nothing more than a simple helper, which takes the input parameters and does a few calculations on them. If there's a need to encapsulate the knowledge about how the pool works and e.g. how much is witdrawable, maybe we should create a library for other contracts? That'd be also cheaper to use without making full inter-contract calls.~

~I've pushed the second commit dropping `senderBalance`. It can be either squashed or reverted.~

Just drops `withdrawable`.