### PR TITLE
Rename sub-sender to account

### DIFF
--- a/src/DaiDripsHub.sol
+++ b/src/DaiDripsHub.sol
@@ -56,7 +56,7 @@ contract DaiDripsHub is ERC20DripsHub {
         return updateSender(lastUpdate, lastBalance, currReceivers, balanceDelta, newReceivers);
     }
 
-    /// @notice Updates all the parameters of a sub-sender of the sender of the message
+    /// @notice Updates all the parameters of an account of the sender of the message
     /// and permits spending sender's Dai by the drips hub.
     /// This function is an extension of `updateSender`, see its documentation for more details.
     ///
@@ -64,7 +64,7 @@ contract DaiDripsHub is ERC20DripsHub {
     /// These parameters will be passed to the Dai contract by this function.
     /// @param permitArgs The Dai permission arguments.
     function updateSenderAndPermit(
-        uint256 subSenderId,
+        uint256 account,
         uint64 lastUpdate,
         uint128 lastBalance,
         Receiver[] calldata currReceivers,
@@ -75,7 +75,7 @@ contract DaiDripsHub is ERC20DripsHub {
         _permit(permitArgs);
         return
             updateSender(
-                subSenderId,
+                account,
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -100,7 +100,7 @@ contract DaiDripsHub is ERC20DripsHub {
         give(receiver, amt);
     }
 
-    /// @notice Gives funds from the sub-sender of the sender of the message to the receiver
+    /// @notice Gives funds from the account of the sender of the message to the receiver
     /// and permits spending sender's Dai by the drips hub.
     /// This function is an extension of `give` see its documentation for more details.
     ///
@@ -108,13 +108,13 @@ contract DaiDripsHub is ERC20DripsHub {
     /// These parameters will be passed to the Dai contract by this function.
     /// @param permitArgs The Dai permission arguments.
     function giveAndPermit(
-        uint256 subSenderId,
+        uint256 account,
         address receiver,
         uint128 amt,
         PermitArgs calldata permitArgs
     ) public {
         _permit(permitArgs);
-        give(subSenderId, receiver, amt);
+        give(account, receiver, amt);
     }
 
     /// @notice Permits the drips hub to spend the message sender's Dai.

--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -45,7 +45,7 @@ contract ERC20DripsHub is DripsHub {
     ) public returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _updateSender(
-                _senderId(msg.sender),
+                _userOrAccount(msg.sender),
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -67,7 +67,7 @@ contract ERC20DripsHub is DripsHub {
     ) public payable returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _updateSender(
-                _senderId(msg.sender, account),
+                _userOrAccount(msg.sender, account),
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -81,7 +81,7 @@ contract ERC20DripsHub is DripsHub {
     /// @param receiver The receiver
     /// @param amt The sent amount
     function give(address receiver, uint128 amt) public {
-        _give(_senderId(msg.sender), receiver, amt);
+        _give(_userOrAccount(msg.sender), receiver, amt);
     }
 
     /// @notice Gives funds from the account of the sender of the message to the receiver.
@@ -94,7 +94,7 @@ contract ERC20DripsHub is DripsHub {
         address receiver,
         uint128 amt
     ) public {
-        _give(_senderId(msg.sender, account), receiver, amt);
+        _give(_userOrAccount(msg.sender, account), receiver, amt);
     }
 
     /// @notice Collects received funds and sets a new list of drips receivers

--- a/src/ERC20DripsHub.sol
+++ b/src/ERC20DripsHub.sol
@@ -54,11 +54,11 @@ contract ERC20DripsHub is DripsHub {
             );
     }
 
-    /// @notice Updates all the parameters of a sub-sender of the sender of the message.
+    /// @notice Updates all the parameters of an account of the sender of the message.
     /// See `updateSender` for more details
-    /// @param subSenderId The id of the sender's sub-sender
+    /// @param account The sender's account
     function updateSender(
-        uint256 subSenderId,
+        uint256 account,
         uint64 lastUpdate,
         uint128 lastBalance,
         Receiver[] calldata currReceivers,
@@ -67,7 +67,7 @@ contract ERC20DripsHub is DripsHub {
     ) public payable returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _updateSender(
-                _senderId(msg.sender, subSenderId),
+                _senderId(msg.sender, account),
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -84,17 +84,17 @@ contract ERC20DripsHub is DripsHub {
         _give(_senderId(msg.sender), receiver, amt);
     }
 
-    /// @notice Gives funds from the sub-sender of the sender of the message to the receiver.
+    /// @notice Gives funds from the account of the sender of the message to the receiver.
     /// The receiver can collect them immediately.
-    /// @param subSenderId The ID of the sub-sender
+    /// @param account The user's account
     /// @param receiver The receiver
     /// @param amt The given amount
     function give(
-        uint256 subSenderId,
+        uint256 account,
         address receiver,
         uint128 amt
     ) public {
-        _give(_senderId(msg.sender, subSenderId), receiver, amt);
+        _give(_senderId(msg.sender, account), receiver, amt);
     }
 
     /// @notice Collects received funds and sets a new list of drips receivers

--- a/src/EthDripsHub.sol
+++ b/src/EthDripsHub.sol
@@ -38,7 +38,7 @@ contract EthDripsHub is DripsHub {
     ) public payable returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _updateSender(
-                _senderId(msg.sender),
+                _userOrAccount(msg.sender),
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -60,7 +60,7 @@ contract EthDripsHub is DripsHub {
     ) public payable returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _updateSender(
-                _senderId(msg.sender, account),
+                _userOrAccount(msg.sender, account),
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -82,7 +82,7 @@ contract EthDripsHub is DripsHub {
     /// The receiver can collect them immediately.
     /// @param receiver The receiver
     function give(address receiver) public payable {
-        _give(_senderId(msg.sender), receiver, uint128(msg.value));
+        _give(_userOrAccount(msg.sender), receiver, uint128(msg.value));
     }
 
     /// @notice Gives funds from the account of the sender of the message to the receiver.
@@ -90,7 +90,7 @@ contract EthDripsHub is DripsHub {
     /// @param account The user's account
     /// @param receiver The receiver
     function give(uint256 account, address receiver) public payable {
-        _give(_senderId(msg.sender, account), receiver, uint128(msg.value));
+        _give(_userOrAccount(msg.sender, account), receiver, uint128(msg.value));
     }
 
     /// @notice Collects received funds and sets a new list of drips receivers

--- a/src/EthDripsHub.sol
+++ b/src/EthDripsHub.sol
@@ -47,11 +47,11 @@ contract EthDripsHub is DripsHub {
             );
     }
 
-    /// @notice Updates all the parameters of a sub-sender of the sender of the message.
+    /// @notice Updates all the parameters of an account of the sender of the message.
     /// See `updateSender` for more details
-    /// @param subSenderId The id of the sender's sub-sender
+    /// @param account The sender's account
     function updateSender(
-        uint256 subSenderId,
+        uint256 account,
         uint64 lastUpdate,
         uint128 lastBalance,
         Receiver[] calldata currReceivers,
@@ -60,7 +60,7 @@ contract EthDripsHub is DripsHub {
     ) public payable returns (uint128 newBalance, int128 realBalanceDelta) {
         return
             _updateSender(
-                _senderId(msg.sender, subSenderId),
+                _senderId(msg.sender, account),
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -85,12 +85,12 @@ contract EthDripsHub is DripsHub {
         _give(_senderId(msg.sender), receiver, uint128(msg.value));
     }
 
-    /// @notice Gives funds from the sub-sender of the sender of the message to the receiver.
+    /// @notice Gives funds from the account of the sender of the message to the receiver.
     /// The receiver can collect them immediately.
-    /// @param subSenderId The id of the giver's sub-sender
+    /// @param account The user's account
     /// @param receiver The receiver
-    function give(uint256 subSenderId, address receiver) public payable {
-        _give(_senderId(msg.sender, subSenderId), receiver, uint128(msg.value));
+    function give(uint256 account, address receiver) public payable {
+        _give(_senderId(msg.sender, account), receiver, uint128(msg.value));
     }
 
     /// @notice Collects received funds and sets a new list of drips receivers

--- a/src/test/DripsHub.t.sol
+++ b/src/test/DripsHub.t.sol
@@ -17,8 +17,8 @@ abstract contract DripsHubTest is DripsHubUserUtils {
     DripsHubUser private sender2;
     DripsHubUser private receiver2;
     DripsHubUser private receiver3;
-    uint256 private constant SUB_SENDER_1 = 1;
-    uint256 private constant SUB_SENDER_2 = 2;
+    uint256 private constant ACCOUNT_1 = 1;
+    uint256 private constant ACCOUNT_2 = 2;
 
     // Must be called once from child contract `setUp`
     function setUp(DripsHub dripsHub_) internal {
@@ -361,16 +361,16 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         collect(sender2, receiver, 10);
     }
 
-    function testSenderAndSubSenderAreIndependent() public {
+    function testSenderAndTheirAccountAreIndependent() public {
         updateSender(sender, 0, 5, receivers(receiver1, 1));
         warpBy(3);
-        updateSender(sender, SUB_SENDER_1, 0, 8, receivers(receiver1, 2, receiver2, 1));
+        updateSender(sender, ACCOUNT_1, 0, 8, receivers(receiver1, 2, receiver2, 1));
         warpBy(1);
         // Sender had 4 seconds paying 1 per second
         changeBalance(sender, 1, 0);
         warpBy(1);
-        // Sender sub-sender1 had 2 seconds paying 3 per second
-        changeBalance(sender, SUB_SENDER_1, 2, 0);
+        // Sender account1 had 2 seconds paying 3 per second
+        changeBalance(sender, ACCOUNT_1, 2, 0);
         warpToCycleEnd();
         // Receiver1 had 4 second paying 1 per second and 2 seconds paying 2 per second
         collect(receiver1, 8);
@@ -378,16 +378,16 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         collect(receiver2, 2);
     }
 
-    function testUserSubSendersAreIndependent() public {
-        updateSender(sender, SUB_SENDER_1, 0, 5, receivers(receiver1, 1));
+    function testUserTheirAccountAreIndependent() public {
+        updateSender(sender, ACCOUNT_1, 0, 5, receivers(receiver1, 1));
         warpBy(3);
-        updateSender(sender, SUB_SENDER_2, 0, 8, receivers(receiver1, 2, receiver2, 1));
+        updateSender(sender, ACCOUNT_2, 0, 8, receivers(receiver1, 2, receiver2, 1));
         warpBy(1);
-        // Sender sub-sender1 had 4 seconds paying 1 per second
-        changeBalance(sender, SUB_SENDER_1, 1, 0);
+        // Sender account1 had 4 seconds paying 1 per second
+        changeBalance(sender, ACCOUNT_1, 1, 0);
         warpBy(1);
-        // Sender sub-sender2 had 2 seconds paying 3 per second
-        changeBalance(sender, SUB_SENDER_2, 2, 0);
+        // Sender account2 had 2 seconds paying 3 per second
+        changeBalance(sender, ACCOUNT_2, 2, 0);
         warpToCycleEnd();
         // Receiver1 had 4 second paying 1 per second and 2 seconds paying 2 per second
         collect(receiver1, 8);
@@ -395,16 +395,16 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         collect(receiver2, 2);
     }
 
-    function testSubSendersOfDifferentUsersAreIndependent() public {
-        updateSender(sender1, SUB_SENDER_1, 0, 5, receivers(receiver1, 1));
+    function testAccountsOfDifferentUsersAreIndependent() public {
+        updateSender(sender1, ACCOUNT_1, 0, 5, receivers(receiver1, 1));
         warpBy(3);
-        updateSender(sender2, SUB_SENDER_1, 0, 8, receivers(receiver1, 2, receiver2, 1));
+        updateSender(sender2, ACCOUNT_1, 0, 8, receivers(receiver1, 2, receiver2, 1));
         warpBy(1);
-        // Sender1 sub-sender1 had 4 seconds paying 1 per second
-        changeBalance(sender1, SUB_SENDER_1, 1, 0);
+        // Sender1 account1 had 4 seconds paying 1 per second
+        changeBalance(sender1, ACCOUNT_1, 1, 0);
         warpBy(1);
-        // Sender2 sub-sender1 had 2 seconds paying 3 per second
-        changeBalance(sender2, SUB_SENDER_1, 2, 0);
+        // Sender2 account1 had 2 seconds paying 3 per second
+        changeBalance(sender2, ACCOUNT_1, 2, 0);
         warpToCycleEnd();
         // Receiver1 had 4 second paying 1 per second and 2 seconds paying 2 per second
         collect(receiver1, 8);
@@ -592,8 +592,8 @@ abstract contract DripsHubTest is DripsHubUserUtils {
         collect(receiver, 10);
     }
 
-    function testFundsGivenFromSubSenderCanBeCollected() public {
-        sender.give(SUB_SENDER_1, address(receiver), 10);
+    function testFundsGivenFromAccountCanBeCollected() public {
+        sender.give(ACCOUNT_1, address(receiver), 10);
         collect(receiver, 10);
     }
 }

--- a/src/test/DripsHubUser.t.sol
+++ b/src/test/DripsHubUser.t.sol
@@ -19,7 +19,7 @@ abstract contract DripsHubUser {
     ) public virtual returns (uint128 newBalance, int128 realBalanceDelta);
 
     function updateSender(
-        uint256 subSenderId,
+        uint256 account,
         uint64 lastUpdate,
         uint128 lastBalance,
         Receiver[] calldata currReceivers,
@@ -30,7 +30,7 @@ abstract contract DripsHubUser {
     function give(address receiver, uint128 amt) public virtual;
 
     function give(
-        uint256 subSenderId,
+        uint256 account,
         address receiver,
         uint128 amt
     ) public virtual;
@@ -75,8 +75,8 @@ abstract contract DripsHubUser {
         return getDripsHub().senderStateHash(address(this));
     }
 
-    function senderStateHash(uint256 subSenderId) public view returns (bytes32 weightsHash) {
-        return getDripsHub().senderStateHash(address(this), subSenderId);
+    function senderStateHash(uint256 account) public view returns (bytes32 weightsHash) {
+        return getDripsHub().senderStateHash(address(this), account);
     }
 
     function hashDripsReceivers(DripsReceiver[] calldata receivers) public view returns (bytes32) {
@@ -122,7 +122,7 @@ contract ERC20DripsHubUser is DripsHubUser {
     }
 
     function updateSender(
-        uint256 subSenderId,
+        uint256 account,
         uint64 lastUpdate,
         uint128 lastBalance,
         Receiver[] calldata currReceivers,
@@ -132,7 +132,7 @@ contract ERC20DripsHubUser is DripsHubUser {
         if (balanceDelta > 0) dripsHub.erc20().approve(address(dripsHub), uint128(balanceDelta));
         return
             dripsHub.updateSender(
-                subSenderId,
+                account,
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -147,12 +147,12 @@ contract ERC20DripsHubUser is DripsHubUser {
     }
 
     function give(
-        uint256 subSenderId,
+        uint256 account,
         address receiver,
         uint128 amt
     ) public override {
         dripsHub.erc20().approve(address(dripsHub), amt);
-        dripsHub.give(subSenderId, receiver, amt);
+        dripsHub.give(account, receiver, amt);
     }
 
     function setDripsReceivers(
@@ -201,7 +201,7 @@ contract EthDripsHubUser is DripsHubUser {
     }
 
     function updateSender(
-        uint256 subSenderId,
+        uint256 account,
         uint64 lastUpdate,
         uint128 lastBalance,
         Receiver[] calldata currReceivers,
@@ -212,7 +212,7 @@ contract EthDripsHubUser is DripsHubUser {
         uint128 reduceBalance = balanceDelta < 0 ? uint128(-balanceDelta) : 0;
         return
             dripsHub.updateSender{value: value}(
-                subSenderId,
+                account,
                 lastUpdate,
                 lastBalance,
                 currReceivers,
@@ -226,11 +226,11 @@ contract EthDripsHubUser is DripsHubUser {
     }
 
     function give(
-        uint256 subSenderId,
+        uint256 account,
         address receiver,
         uint128 amt
     ) public override {
-        dripsHub.give{value: amt}(subSenderId, receiver);
+        dripsHub.give{value: amt}(account, receiver);
     }
 
     function setDripsReceivers(


### PR DESCRIPTION
Unfortunately `alias` is a solidity keyword :grimacing: IMO `account` is fine too.